### PR TITLE
Perf: Add volume name label

### DIFF
--- a/collectors/perf.go
+++ b/collectors/perf.go
@@ -55,238 +55,238 @@ func NewPerfCollector() *PerfCollector {
 		AvgDiskBytesPerRead: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_bytes_per_read"),
 			"AvgDiskBytesPerRead",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskBytesPerRead_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_bytes_per_read_base"),
 			"AvgDiskBytesPerRead_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskBytesPerTransfer: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_bytes_per_transfer"),
 			"AvgDiskBytesPerTransfer",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskBytesPerTransfer_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_bytes_per_transfer_base"),
 			"AvgDiskBytesPerTransfer_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskBytesPerWrite: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_bytes_per_write"),
 			"AvgDiskBytesPerWrite",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskBytesPerWrite_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_bytes_per_write_base"),
 			"AvgDiskBytesPerWrite_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskQueueLength: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_queue_length"),
 			"AvgDiskQueueLength",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskReadQueueLength: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_read_queue_length"),
 			"AvgDiskReadQueueLength",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskSecPerRead: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_sec_per_read"),
 			"AvgDiskSecPerRead",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskSecPerRead_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_sec_per_read_base"),
 			"AvgDiskSecPerRead_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskSecPerTransfer: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_sec_per_transfer"),
 			"AvgDiskSecPerTransfer",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskSecPerTransfer_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_sec_per_transfer_base"),
 			"AvgDiskSecPerTransfer_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskSecPerWrite: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_sec_per_write"),
 			"AvgDiskSecPerWrite",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskSecPerWrite_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_sec_per_write_base"),
 			"AvgDiskSecPerWrite_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		AvgDiskWriteQueueLength: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "avg_disk_write_queue_length"),
 			"AvgDiskWriteQueueLength",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		CurrentDiskQueueLength: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "current_disk_queue_length"),
 			"CurrentDiskQueueLength",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		DiskBytesPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "disk_bytes_per_sec"),
 			"DiskBytesPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		DiskReadBytesPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "disk_read_bytes_per_sec"),
 			"DiskReadBytesPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		DiskReadsPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "disk_reads_per_sec"),
 			"DiskReadsPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		DiskTransfersPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "disk_transfers_per_sec"),
 			"DiskTransfersPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		DiskWriteBytesPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "disk_write_bytes_per_sec"),
 			"DiskWriteBytesPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		DiskWritesPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "disk_writes_per_sec"),
 			"DiskWritesPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		FreeMegabytes: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "free_megabytes"), // XXX in bytes
 			"FreeMegabytes",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentDiskReadTime: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_disk_read_time"),
 			"PercentDiskReadTime",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentDiskReadTime_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_disk_read_time_base"),
 			"PercentDiskReadTime_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentDiskTime: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_disk_time"),
 			"PercentDiskTime",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentDiskTime_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_disk_time_base"),
 			"PercentDiskTime_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentDiskWriteTime: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_disk_write_time"),
 			"PercentDiskWriteTime",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentDiskWriteTime_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_disk_write_time_base"),
 			"PercentDiskWriteTime_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentFreeSpace: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_free_space"),
 			"PercentFreeSpace",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentFreeSpace_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_free_space_base"),
 			"PercentFreeSpace_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentIdleTime: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_idle_time"),
 			"PercentIdleTime",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		PercentIdleTime_Base: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "percent_idle_time_base"),
 			"PercentIdleTime_Base",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 
 		SplitIOPerSec: prometheus.NewDesc(
 			prometheus.BuildFQName(wmiNamespace, "perf", "split_io_per_sec"),
 			"SplitIOPerSec",
-			nil,
+			[]string{"volume"},
 			nil,
 		),
 	}
@@ -342,6 +342,7 @@ func (c *PerfCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 type Win32_PerfRawData_PerfDisk_LogicalDisk struct {
+	Name                         string
 	AvgDiskBytesPerRead          uint64
 	AvgDiskBytesPerRead_Base     uint32
 	AvgDiskBytesPerTransfer      uint64
@@ -385,209 +386,245 @@ func (c *PerfCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, 
 		return nil, err
 	}
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskBytesPerRead,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskBytesPerRead),
-	)
+	for _, volume := range dst {
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskBytesPerRead,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskBytesPerRead),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskBytesPerRead_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskBytesPerRead_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskBytesPerRead_Base,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskBytesPerRead_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskBytesPerTransfer,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskBytesPerTransfer),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskBytesPerTransfer,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskBytesPerTransfer),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskBytesPerTransfer_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskBytesPerTransfer_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskBytesPerTransfer_Base,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskBytesPerTransfer_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskBytesPerWrite,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskBytesPerWrite),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskBytesPerWrite,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskBytesPerWrite),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskBytesPerWrite_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskBytesPerWrite_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskBytesPerWrite_Base,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskBytesPerWrite_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskQueueLength,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskQueueLength),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskQueueLength,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskQueueLength),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskReadQueueLength,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskReadQueueLength),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskReadQueueLength,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskReadQueueLength),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskSecPerRead,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskSecPerRead),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskSecPerRead,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskSecPerRead),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskSecPerRead_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskSecPerRead_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskSecPerRead_Base,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskSecPerRead_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskSecPerTransfer,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskSecPerTransfer),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskSecPerTransfer,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskSecPerTransfer),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskSecPerTransfer_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskSecPerTransfer_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskSecPerTransfer_Base,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskSecPerTransfer_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskSecPerWrite,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskSecPerWrite),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskSecPerWrite,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskSecPerWrite),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskSecPerWrite_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskSecPerWrite_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskSecPerWrite_Base,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskSecPerWrite_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.AvgDiskWriteQueueLength,
-		prometheus.GaugeValue,
-		float64(dst[0].AvgDiskWriteQueueLength),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.AvgDiskWriteQueueLength,
+			prometheus.GaugeValue,
+			float64(volume.AvgDiskWriteQueueLength),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.CurrentDiskQueueLength,
-		prometheus.GaugeValue,
-		float64(dst[0].CurrentDiskQueueLength),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.CurrentDiskQueueLength,
+			prometheus.GaugeValue,
+			float64(volume.CurrentDiskQueueLength),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.DiskBytesPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].DiskBytesPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.DiskBytesPerSec,
+			prometheus.GaugeValue,
+			float64(volume.DiskBytesPerSec),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.DiskReadBytesPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].DiskReadBytesPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.DiskReadBytesPerSec,
+			prometheus.GaugeValue,
+			float64(volume.DiskReadBytesPerSec),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.DiskReadsPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].DiskReadsPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.DiskReadsPerSec,
+			prometheus.GaugeValue,
+			float64(volume.DiskReadsPerSec),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.DiskTransfersPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].DiskTransfersPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.DiskTransfersPerSec,
+			prometheus.GaugeValue,
+			float64(volume.DiskTransfersPerSec),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.DiskWriteBytesPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].DiskWriteBytesPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.DiskWriteBytesPerSec,
+			prometheus.GaugeValue,
+			float64(volume.DiskWriteBytesPerSec),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.DiskWritesPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].DiskWritesPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.DiskWritesPerSec,
+			prometheus.GaugeValue,
+			float64(volume.DiskWritesPerSec),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.FreeMegabytes,
-		prometheus.GaugeValue,
-		float64(dst[0].FreeMegabytes),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.FreeMegabytes,
+			prometheus.GaugeValue,
+			float64(volume.FreeMegabytes),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentDiskReadTime,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentDiskReadTime),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentDiskReadTime,
+			prometheus.GaugeValue,
+			float64(volume.PercentDiskReadTime),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentDiskReadTime_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentDiskReadTime_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentDiskReadTime_Base,
+			prometheus.GaugeValue,
+			float64(volume.PercentDiskReadTime_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentDiskTime,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentDiskTime),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentDiskTime,
+			prometheus.GaugeValue,
+			float64(volume.PercentDiskTime),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentDiskTime_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentDiskTime_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentDiskTime_Base,
+			prometheus.GaugeValue,
+			float64(volume.PercentDiskTime_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentDiskWriteTime,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentDiskWriteTime),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentDiskWriteTime,
+			prometheus.GaugeValue,
+			float64(volume.PercentDiskWriteTime),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentDiskWriteTime_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentDiskWriteTime_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentDiskWriteTime_Base,
+			prometheus.GaugeValue,
+			float64(volume.PercentDiskWriteTime_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentFreeSpace,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentFreeSpace),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentFreeSpace,
+			prometheus.GaugeValue,
+			float64(volume.PercentFreeSpace),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentFreeSpace_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentFreeSpace_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentFreeSpace_Base,
+			prometheus.GaugeValue,
+			float64(volume.PercentFreeSpace_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentIdleTime,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentIdleTime),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentIdleTime,
+			prometheus.GaugeValue,
+			float64(volume.PercentIdleTime),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.PercentIdleTime_Base,
-		prometheus.GaugeValue,
-		float64(dst[0].PercentIdleTime_Base),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.PercentIdleTime_Base,
+			prometheus.GaugeValue,
+			float64(volume.PercentIdleTime_Base),
+			volume.Name,
+		)
 
-	ch <- prometheus.MustNewConstMetric(
-		c.SplitIOPerSec,
-		prometheus.GaugeValue,
-		float64(dst[0].SplitIOPerSec),
-	)
+		ch <- prometheus.MustNewConstMetric(
+			c.SplitIOPerSec,
+			prometheus.GaugeValue,
+			float64(volume.SplitIOPerSec),
+			volume.Name,
+		)
+	}
 
 	return nil, nil
 }


### PR DESCRIPTION
As per the TODO list on the wiki, I added volume labels to the perf collector. I also added a whitelist/blacklist functionality similar to what is used in other exporters, defaulting to excluding the `_Total` "meta-counter".

By the way, shouldn't the collector be named something like logical_disk rather than perf? 