### PR TITLE
Remove branch requirement for deployments, since it seems broken in combination with tags

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,5 +43,4 @@ deploy:
     draft: false
     prerelease: false
     on:
-      branch: master
       appveyor_repo_tag: true


### PR DESCRIPTION
This fixes the fact that AppVeyor currently does not upload releases even though they are tagged. Apparently the branch name is replaced by the tag name (in contraditiction with their examples...)