### PR TITLE
simplify appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,18 +4,12 @@ os: Windows Server 2012 R2
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.7
 
 clone_folder: c:\gopath\src\github.com\martinlindhe\wmi_exporter
 
 install:
   - go version
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
-  - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
-  - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
-  - go version
-  - go env
   - go get -u github.com/kardianos/govendor
 
 build_script:


### PR DESCRIPTION
It seems appveyor has been upgraded to have go 1.7.1 out-of-box.

so this patch simplifies appveyor.yml to remove the custom "install go 1.7" build step. should speed up CI by a few seconds