### PR TITLE
Build both x86 and amd64 artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,16 @@ os: Windows Server 2012 R2
 environment:
   GOPATH: c:\gopath
   matrix:
-    #- MSI_ARCH: amd64
-    #  GO_BUILDARCH: amd64
+    - MSI_ARCH: amd64
+      GOARCH: amd64
     - MSI_ARCH: x86
-      GO_BUILDARCH: 386
+      GOARCH: 386
 
 clone_folder: c:\gopath\src\github.com\martinlindhe\wmi_exporter
 
 install:
   - go version
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - set PATH=%GOPATH%\bin;c:\go\bin;%GOPATH%\bin\windows_%GOARCH%;%PATH%
   - go get -u github.com/kardianos/govendor
   - go get -u github.com/prometheus/promu
   - choco install gitversion.portable -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,11 @@ os: Windows Server 2012 R2
 
 environment:
   GOPATH: c:\gopath
+  matrix:
+    - MSI_ARCH: amd64
+      GOARCH: amd64
+    - MSI_ARCH: x86
+      GOARCH: 386
 
 clone_folder: c:\gopath\src\github.com\martinlindhe\wmi_exporter
 
@@ -23,13 +28,16 @@ build_script:
         # The MSI version is not semver compliant, so just take the numerical parts
         $Version = $env:APPVEYOR_REPO_TAG_NAME -replace '^v?([0-9\.]+).*$','$1'
         Write-Verbose "Setting msi version to $Version"
-        .\installer\build.ps1 -PathToExecutable .\wmi_exporter.exe -Version $Version -Arch "amd64"
-        Push-AppveyorArtifact installer\Output\wmi_exporter-$Version-amd64.msi -DeploymentName Installer
+        .\installer\build.ps1 -PathToExecutable .\wmi_exporter.exe -Version $Version -Arch "$env:MSI_ARCH"
+        Push-AppveyorArtifact installer\Output\wmi_exporter-$Version-$env:MSI_ARCH.msi -DeploymentName Installer
       }
+
+after_build:
+  - 7z a wmi_exporter-%MSI_ARCH%.zip wmi_exporter.exe
 
 artifacts:
   - name: Executable
-    path: wmi_exporter.exe
+    path: 'wmi_exporter-*.zip'
 
 deploy:
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ install:
 
 build_script:
   - ps: gitversion /output json /showvariable FullSemVer | Set-Content VERSION -PassThru
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - govendor test -v +local
   - promu build -v .
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ os: Windows Server 2012 R2
 environment:
   GOPATH: c:\gopath
   matrix:
-    - MSI_ARCH: amd64
-      GOARCH: amd64
+    #- MSI_ARCH: amd64
+    #  GO_BUILDARCH: amd64
     - MSI_ARCH: x86
-      GOARCH: 386
+      GO_BUILDARCH: 386
 
 clone_folder: c:\gopath\src\github.com\martinlindhe\wmi_exporter
 
@@ -21,6 +21,7 @@ install:
 
 build_script:
   - ps: gitversion /output json /showvariable FullSemVer | Set-Content VERSION -PassThru
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - govendor test -v +local
   - promu build -v .
   - ps: |


### PR DESCRIPTION
This PR adds a build matrix so that both x86 and amd64 versions are built. Fixes #47.

_Note: I don't have access to a git client at the moment, so this should be squashed as a PR-merge option to remove AppVeyor experimentation commits_