### PR TITLE
Add [defaults] placeholder support to collectors.enabled

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+type expansionTestCase struct {
+	input          string
+	expectedOutput []string
+}
+
+func TestExpandEnabled(t *testing.T) {
+	expansionTests := []expansionTestCase{
+		{"", []string{}},
+		// Default case
+		{"cs,os", []string{"cs", "os"}},
+		// Placeholder expansion
+		{defaultCollectorsPlaceholder, strings.Split(defaultCollectors, ",")},
+		// De-duplication
+		{"cs,cs", []string{"cs"}},
+		// De-duplicate placeholder
+		{defaultCollectorsPlaceholder + "," + defaultCollectorsPlaceholder, strings.Split(defaultCollectors, ",")},
+		// Composite case
+		{"foo," + defaultCollectorsPlaceholder + ",bar", append(strings.Split(defaultCollectors, ","), "foo", "bar")},
+	}
+
+	for _, testCase := range expansionTests {
+		output := expandEnabledCollectors(testCase.input)
+		sort.Strings(output)
+
+		success := true
+		if len(output) != len(testCase.expectedOutput) {
+			success = false
+		} else {
+			sort.Strings(testCase.expectedOutput)
+			for idx := range output {
+				if output[idx] != testCase.expectedOutput[idx] {
+					success = false
+					break
+				}
+			}
+		}
+		if !success {
+			t.Error("For", testCase.input, "expected", testCase.expectedOutput, "got", output)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #44.

By adding the placeholder `[defaults]` in the list sent to `-collectors.enabled`, the user can add extra collectors without having to keep the defaults enabled. This makes updates when having extra collectors enabled, since you no longer need to update the list with new default collectors. For example, our web servers currently have `-collectors.enabled "cpu,cs,iis,logical_disk,net,os,system"`, just to enable `iis`. When we update to the latest release which supports the `service´ collector, we need to update our configuration to benefit from it.

I wrote a few tests for the merging logic, but I'm not all that pleased with the amount of string juggling needed in the tests themselves. Any ideas for improvements?