### PR TITLE
Add DisplayName and Description to Windows service

### DIFF
--- a/installer/wmi_exporter.wxs
+++ b/installer/wmi_exporter.wxs
@@ -36,7 +36,7 @@
         <File Id="wmi_exporter.exe" Name="wmi_exporter.exe" Source="Work\wmi_exporter.exe" KeyPath="yes">
           <fw:FirewallException Id="MetricsEndpoint" Name="WMI Exporter (HTTP [LISTEN_PORT])" Description="WMI Exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" Scope="any" IgnoreFailure="yes" />
         </File>
-        <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="-log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [ListenFlag] [MetricsPathFlag]" />
+        <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" DisplayName="WMI exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="-log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [ListenFlag] [MetricsPathFlag]" />
         <ServiceControl Id="ServiceStateControl" Name="wmi_exporter" Remove="uninstall" Start="install" Stop="both" />
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
Fixes #99.

I opted to set the display name to just "WMI Exporter" rather than the arguable clearer "Prometheus WMI exporter" to avoid throwing people off who might be used to it being called wmi_exporter in the list. Opinions? Maybe too change-averse? :)

@lubyou