### PR TITLE
README: update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ See [open issues](https://github.com/martinlindhe/wmi_exporter/issues)
 ## Usage
 
     go get -u github.com/kardianos/govendor
+    go get -u github.com/prometheus/promu
     go get -u github.com/martinlindhe/wmi_exporter
     cd $env:GOPATH/src/github.com/martinlindhe/wmi_exporter
-    govendor build +local
+    promu build -v .
     .\wmi_exporter.exe
 
 The prometheus metrics will be exposed on [localhost:9182](http://localhost:9182)


### PR DESCRIPTION
It seems I forgot to update README with the https://github.com/martinlindhe/wmi_exporter/commit/c5d7bb8375011457463ed8743a35da412a650371 change
