### PR TITLE
Add MSMQ collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ dns | [Win32_PerfRawData_DNS_DNS](https://technet.microsoft.com/en-us/library/cc
 iis | [Win32_PerfRawData_W3SVC_WebService](https://msdn.microsoft.com/en-us/library/aa394345) IIS metrics |
 logical_disk | [Win32_PerfRawData_PerfDisk_LogicalDisk](https://msdn.microsoft.com/en-us/windows/hardware/aa394307(v=vs.71)) metrics (disk I/O) | &#10003;
 net | [Win32_PerfRawData_Tcpip_NetworkInterface](https://technet.microsoft.com/en-us/security/aa394340(v=vs.80)) metrics (network interface I/O) | &#10003;
+msmq | [Win32_PerfRawData_MSMQ_MSMQQueue](http://wutils.com/wmi/root/cimv2/win32_perfrawdata_msmq_msmqqueue/) metrics (MSMQ/journal count) | 
 os | [Win32_OperatingSystem](https://msdn.microsoft.com/en-us/library/aa394239) metrics (memory, processes, users) | &#10003;
 process | [Win32_PerfRawData_PerfProc_Process](https://msdn.microsoft.com/en-us/library/aa394323(v=vs.85).aspx) metrics (per-process stats) |
 service | [Win32_Service](https://msdn.microsoft.com/en-us/library/aa394418(v=vs.85).aspx) metrics (service states) | &#10003;

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -1,0 +1,127 @@
+// returns data points from Win32_PerfRawData_MSMQ_MSMQQueue
+// <add link to documentation here> - Win32_PerfRawData_MSMQ_MSMQQueue class
+package collector
+
+import (
+	"log"
+	"flag"
+	"bytes"
+	"strings"
+	"github.com/StackExchange/wmi"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	Factories["msmq"] = NewMSMQCollector
+}
+
+var (
+	msmqWhereClause = flag.String("collector.msmq.msmq-where", "", "WQL 'where' clause to use in WMI metrics query. Limits the response to the msmqs you specify and reduces the size of the response.")
+)
+
+// A Win32_PerfRawData_MSMQ_MSMQQueueCollector is a Prometheus collector for WMI Win32_PerfRawData_MSMQ_MSMQQueue metrics
+type Win32_PerfRawData_MSMQ_MSMQQueueCollector struct {
+	BytesinJournalQueue    *prometheus.Desc
+	BytesinQueue           *prometheus.Desc
+	MessagesinJournalQueue *prometheus.Desc
+	MessagesinQueue        *prometheus.Desc
+	
+	queryWhereClause string
+}
+
+// NewWin32_PerfRawData_MSMQ_MSMQQueueCollector ...
+func NewMSMQCollector() (Collector, error) {
+	const subsystem = "msmq"
+	
+	var wc bytes.Buffer
+	if *msmqWhereClause != "" {
+		wc.WriteString("WHERE ")
+		wc.WriteString(*msmqWhereClause)
+		log.Println("warning: No where-clause specified for msmq collector. This will generate a very large number of metrics!")
+	}
+// else {
+//		log.Println("warning: No where-clause specified for msmq collector. This will generate a very large number of metrics!")
+//	}
+	return &Win32_PerfRawData_MSMQ_MSMQQueueCollector{
+		BytesinJournalQueue: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "bytesin_journal_queue"),
+			"Size of queue journal in bytes",
+			[]string{"name"},
+			nil,
+		),
+		BytesinQueue: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "bytesin_queue"),
+			"Size of queue in bytes",
+			[]string{"name"},
+			nil,
+		),
+		MessagesinJournalQueue: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "messagesin_journal_queue"),
+			"Count messages in queue journal",
+			[]string{"name"},
+			nil,
+		),
+		MessagesinQueue: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "messagesin_queue"),
+			"Count messages in queue",
+			[]string{"name"},
+			nil,
+		),
+		queryWhereClause: wc.String(),
+	}, nil
+}
+
+// Collect sends the metric values for each metric
+// to the provided prometheus Metric channel.
+func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) Collect(ch chan<- prometheus.Metric) error {
+	if desc, err := c.collect(ch); err != nil {
+		log.Println("[ERROR] failed collecting msmq metrics:", desc, err)
+		return err
+	}
+	return nil
+}
+
+type Win32_PerfRawData_MSMQ_MSMQQueue struct {
+	Name string
+
+	BytesinJournalQueue    uint64
+	BytesinQueue           uint64
+	MessagesinJournalQueue uint64
+	MessagesinQueue        uint64
+}
+
+func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
+	var dst []Win32_PerfRawData_MSMQ_MSMQQueue
+	q := wmi.CreateQuery(&dst, c.queryWhereClause)
+	if err := wmi.Query(q, &dst); err != nil {
+		return nil, err
+	}
+	
+	for _, msmq := range dst {
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesinJournalQueue,
+			prometheus.GaugeValue,
+			float64(dst[0].BytesinJournalQueue),
+			strings.ToLower(msmq.Name),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesinQueue,
+			prometheus.GaugeValue,
+			float64(dst[0].BytesinQueue),
+			strings.ToLower(msmq.Name),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.MessagesinJournalQueue,
+			prometheus.GaugeValue,
+			float64(dst[0].MessagesinJournalQueue),
+			strings.ToLower(msmq.Name),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.MessagesinQueue,
+			prometheus.GaugeValue,
+			float64(dst[0].MessagesinQueue),
+			strings.ToLower(msmq.Name),
+		)
+}
+	return nil, nil
+}

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -98,6 +98,11 @@ func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) collect(ch chan<- prometheus
 	}
 	
 	for _, msmq := range dst {
+
+		if msmq.Name == "Computer Queues" {
+			continue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.BytesinJournalQueue,
 			prometheus.GaugeValue,

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -101,25 +101,25 @@ func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) collect(ch chan<- prometheus
 		ch <- prometheus.MustNewConstMetric(
 			c.BytesinJournalQueue,
 			prometheus.GaugeValue,
-			float64(dst[0].BytesinJournalQueue),
+			float64(msmq.BytesinJournalQueue),
 			strings.ToLower(msmq.Name),
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.BytesinQueue,
 			prometheus.GaugeValue,
-			float64(dst[0].BytesinQueue),
+			float64(msmq.BytesinQueue),
 			strings.ToLower(msmq.Name),
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.MessagesinJournalQueue,
 			prometheus.GaugeValue,
-			float64(dst[0].MessagesinJournalQueue),
+			float64(msmq.MessagesinJournalQueue),
 			strings.ToLower(msmq.Name),
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.MessagesinQueue,
 			prometheus.GaugeValue,
-			float64(dst[0].MessagesinQueue),
+			float64(msmq.MessagesinQueue),
 			strings.ToLower(msmq.Name),
 		)
 }

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -44,25 +44,25 @@ func NewMSMQCollector() (Collector, error) {
 //	}
 	return &Win32_PerfRawData_MSMQ_MSMQQueueCollector{
 		BytesinJournalQueue: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "bytesin_journal_queue"),
+			prometheus.BuildFQName(Namespace, subsystem, "bytes_in_journal_queue"),
 			"Size of queue journal in bytes",
 			[]string{"name"},
 			nil,
 		),
 		BytesinQueue: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "bytesin_queue"),
+			prometheus.BuildFQName(Namespace, subsystem, "bytes_in_queue"),
 			"Size of queue in bytes",
 			[]string{"name"},
 			nil,
 		),
 		MessagesinJournalQueue: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "messagesin_journal_queue"),
+			prometheus.BuildFQName(Namespace, subsystem, "messages_in_journal_queue"),
 			"Count messages in queue journal",
 			[]string{"name"},
 			nil,
 		),
 		MessagesinQueue: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "messagesin_queue"),
+			prometheus.BuildFQName(Namespace, subsystem, "messages_in_queue"),
 			"Count messages in queue",
 			[]string{"name"},
 			nil,


### PR DESCRIPTION
Add MSMQ collector - Win32_PerfRawData_MSMQ_MSMQQueue
Count message and size for both queueu and journal.
metrics:

`# HELP wmi_msmq_messagesin_journal_queue Count messages in queue journal`
`# TYPE wmi_msmq_messagesin_journal_queue gauge`
`wmi_msmq_messagesin_journal_queue{name="msk-fna\\am_q"} 435`

`# HELP wmi_msmq_messagesin_queue Count messages in queue`
`# TYPE wmi_msmq_messagesin_queue gauge`
`wmi_msmq_messagesin_queue{name="msk-fna\\am_mirror_queue"} 2303`

`# HELP wmi_msmq_bytesin_journal_queue Size of queue journal in bytes`
`# TYPE wmi_msmq_bytesin_journal_queue gauge`
`wmi_msmq_bytesin_journal_queue{name="msk-fna\\am_q"} 1.712848e+06`

`# HELP wmi_msmq_bytesin_queue Size of queue in bytes`
`# TYPE wmi_msmq_bytesin_queue gauge`
`wmi_msmq_bytesin_queue{name="msk-fna\\am_mirror_queue"} 4.44604e+06`
