### PR TITLE
Switch to prometheus/common/log for all logging

### DIFF
--- a/collector/ad.go
+++ b/collector/ad.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -455,7 +454,7 @@ func NewADCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *ADCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting ad metrics:", desc, err)
+		log.Error("failed collecting ad metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -3,11 +3,11 @@
 package collector
 
 import (
-	"log"
 	"strings"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -57,7 +57,7 @@ func NewCPUCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *CPUCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting cpu metrics:", desc, err)
+		log.Error("failed collecting cpu metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -4,10 +4,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -44,7 +43,7 @@ func NewCSCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *CSCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting cs metrics:", desc, err)
+		log.Error("failed collecting cs metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -4,10 +4,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -183,7 +182,7 @@ func NewDNSCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *DNSCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting dns metrics:", desc, err)
+		log.Error("failed collecting dns metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/iis.go
+++ b/collector/iis.go
@@ -8,13 +8,13 @@ package collector
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -31,23 +31,23 @@ type simple_version struct {
 func getIISVersion() simple_version {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\InetStp\`, registry.QUERY_VALUE)
 	if err != nil {
-		log.Println("warning: Couldn't open registry to determine IIS version:", err)
+		log.Warn("Couldn't open registry to determine IIS version:", err)
 		return simple_version{}
 	}
 	defer k.Close()
 
 	major, _, err := k.GetIntegerValue("MajorVersion")
 	if err != nil {
-		log.Println("warning: Couldn't open registry to determine IIS version:", err)
+		log.Warn("Couldn't open registry to determine IIS version:", err)
 		return simple_version{}
 	}
 	minor, _, err := k.GetIntegerValue("MinorVersion")
 	if err != nil {
-		log.Println("warning: Couldn't open registry to determine IIS version:", err)
+		log.Warn("Couldn't open registry to determine IIS version:", err)
 		return simple_version{}
 	}
 
-	log.Printf("Detected IIS %d.%d\n", major, minor)
+	log.Debugf("Detected IIS %d.%d\n", major, minor)
 
 	return simple_version{
 		major: major,
@@ -815,7 +815,7 @@ func NewIISCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *IISCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting iis metrics:", desc, err)
+		log.Error("failed collecting iis metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -6,11 +6,11 @@ package collector
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -138,7 +138,7 @@ func NewLogicalDiskCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *LogicalDiskCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting logical_disk metrics:", desc, err)
+		log.Error("failed collecting logical_disk metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -4,11 +4,11 @@ package collector
 
 import (
 	"bytes"
-	"log"
 	"strings"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -38,7 +38,7 @@ func NewMSMQCollector() (Collector, error) {
 	if *msmqWhereClause != "" {
 		wc.WriteString("WHERE ")
 		wc.WriteString(*msmqWhereClause)
-		log.Println("warning: No where-clause specified for msmq collector. This will generate a very large number of metrics!")
+		log.Warn("No where-clause specified for msmq collector. This will generate a very large number of metrics!")
 	}
 
 	return &Win32_PerfRawData_MSMQ_MSMQQueueCollector{
@@ -74,7 +74,7 @@ func NewMSMQCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting msmq metrics:", desc, err)
+		log.Error("failed collecting msmq metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/net.go
+++ b/collector/net.go
@@ -8,11 +8,11 @@ package collector
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -138,7 +138,7 @@ func NewNetworkCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NetworkCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting net metrics:", desc, err)
+		log.Error("failed collecting net metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -56,7 +55,7 @@ func NewNETFramework_NETCLRExceptionsCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRExceptionsCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrexceptions metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrexceptions metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -49,7 +48,7 @@ func NewNETFramework_NETCLRInteropCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRInteropCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrinterop metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrinterop metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -56,7 +55,7 @@ func NewNETFramework_NETCLRJitCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRJitCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrjit metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrjit metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -91,7 +90,7 @@ func NewNETFramework_NETCLRLoadingCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRLoadingCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrloading metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrloading metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -77,7 +76,7 @@ func NewNETFramework_NETCLRLocksAndThreadsCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRLocksAndThreadsCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrlocksandthreads metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrlocksandthreads metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -115,7 +114,7 @@ func NewNETFramework_NETCLRMemoryCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRMemoryCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrmemory metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrmemory metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -70,7 +69,7 @@ func NewNETFramework_NETCLRRemotingCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRRemotingCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrremoting metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrremoting metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -3,10 +3,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -56,7 +55,7 @@ func NewNETFramework_NETCLRSecurityCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *NETFramework_NETCLRSecurityCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting win32_perfrawdata_netframework_netclrsecurity metrics:", desc, err)
+		log.Error("failed collecting win32_perfrawdata_netframework_netclrsecurity metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/os.go
+++ b/collector/os.go
@@ -4,11 +4,11 @@
 package collector
 
 import (
-	"log"
 	"time"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -115,7 +115,7 @@ func NewOSCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *OSCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting os metrics:", desc, err)
+		log.Error("failed collecting os metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/process.go
+++ b/collector/process.go
@@ -4,12 +4,12 @@ package collector
 
 import (
 	"bytes"
-	"log"
 	"strconv"
 	"strings"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -52,7 +52,7 @@ func NewProcessCollector() (Collector, error) {
 		wc.WriteString("WHERE ")
 		wc.WriteString(*processWhereClause)
 	} else {
-		log.Println("warning: No where-clause specified for process collector. This will generate a very large number of metrics!")
+		log.Warn("No where-clause specified for process collector. This will generate a very large number of metrics!")
 	}
 
 	return &ProcessCollector{
@@ -142,7 +142,7 @@ func NewProcessCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *ProcessCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting process metrics:", desc, err)
+		log.Error("failed collecting process metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/service.go
+++ b/collector/service.go
@@ -4,11 +4,11 @@ package collector
 
 import (
 	"bytes"
-	"log"
 	"strings"
 
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -40,7 +40,7 @@ func NewserviceCollector() (Collector, error) {
 		wc.WriteString("WHERE ")
 		wc.WriteString(*serviceWhereClause)
 	} else {
-		log.Println("warning: No where-clause specified for service collector. This will generate a very large number of metrics!")
+		log.Warn("No where-clause specified for service collector. This will generate a very large number of metrics!")
 	}
 
 	return &serviceCollector{
@@ -64,7 +64,7 @@ func NewserviceCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *serviceCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting service metrics:", desc, err)
+		log.Error("failed collecting service metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/system.go
+++ b/collector/system.go
@@ -4,10 +4,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -72,7 +71,7 @@ func NewSystemCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *SystemCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting system metrics:", desc, err)
+		log.Error("failed collecting system metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -5,10 +5,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -94,7 +93,7 @@ func NewTCPCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *TCPCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collect(ch); err != nil {
-		log.Println("[ERROR] failed collecting tcp metrics:", desc, err)
+		log.Error("failed collecting tcp metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -2,10 +2,9 @@
 package collector
 
 import (
-	"log"
-
 	"github.com/StackExchange/wmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func init() {
@@ -161,11 +160,11 @@ func NewVmwareCollector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *VmwareCollector) Collect(ch chan<- prometheus.Metric) error {
 	if desc, err := c.collectMem(ch); err != nil {
-		log.Println("[ERROR] failed collecting vmware memory metrics:", desc, err)
+		log.Error("failed collecting vmware memory metrics:", desc, err)
 		return err
 	}
 	if desc, err := c.collectCpu(ch); err != nil {
-		log.Println("[ERROR] failed collecting vmware cpu metrics:", desc, err)
+		log.Error("failed collecting vmware cpu metrics:", desc, err)
 		return err
 	}
 	return nil

--- a/exporter.go
+++ b/exporter.go
@@ -86,10 +86,10 @@ func execute(name string, c collector.Collector, ch chan<- prometheus.Metric) {
 	var success float64
 
 	if err != nil {
-		log.Errorf("ERROR: %s collector failed after %fs: %s", name, duration.Seconds(), err)
+		log.Errorf("collector %s failed after %fs: %s", name, duration.Seconds(), err)
 		success = 0
 	} else {
-		log.Debugf("OK: %s collector succeeded after %fs.", name, duration.Seconds())
+		log.Debugf("collector %s succeeded after %fs.", name, duration.Seconds())
 		success = 1
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/tools/collector-generator/collector.template
+++ b/tools/collector-generator/collector.template
@@ -2,10 +2,9 @@
 // <add link to documentation here> - {{ .Class }} class
 package collector
 import (
-    "log"
-
     "github.com/StackExchange/wmi"
     "github.com/prometheus/client_golang/prometheus"
+    "github.com/prometheus/common/log"
 )
 func init() {
     Factories["{{ .CollectorName | toLower }}"] = New{{ .CollectorName }}Collector
@@ -34,7 +33,7 @@ func New{{ .CollectorName }}Collector() (Collector, error) {
 // to the provided prometheus Metric channel.
 func (c *{{ .CollectorName }}Collector) Collect(ch chan<- prometheus.Metric) error {
     if desc, err := c.collect(ch); err != nil {
-        log.Println("[ERROR] failed collecting {{ .CollectorName | toLower }} metrics:", desc, err)
+        log.Error("failed collecting {{ .CollectorName | toLower }} metrics:", desc, err)
         return err
     }
     return nil


### PR DESCRIPTION
Fixes #114.
Possibly we should lock our prometheus/common vendored version, in case the event log support is dropped (as has been discussed)? Not sure if this also requires locking client_golang, though. In that case, might be better to extract the logging stuff into our own package. 