### PR TITLE
Strip carriage-returns from textfile input

### DIFF
--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -1,0 +1,20 @@
+package collector
+
+import (
+	"testing"
+	"strings"
+	"io/ioutil"
+)
+
+func TestCRFilter(t *testing.T) {
+	sr := strings.NewReader("line 1\r\nline 2")
+	cr := carriageReturnFilteringReader{ r: sr }
+	b, err := ioutil.ReadAll(cr)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(b) != "line 1\nline 2" {
+		t.Errorf("Unexpected output %q", b)
+	}
+}


### PR DESCRIPTION
This PR removes all carriage return characters (`\r`) from input files in the textfile collector when they are read by the expfmt parser, since it does not support them.

Fixes #199