### PR TITLE
Refactor wmi query generator to use wildcard selector

### DIFF
--- a/collector/ad.go
+++ b/collector/ad.go
@@ -612,7 +612,7 @@ type Win32_PerfRawData_DirectoryServices_DirectoryServices struct {
 
 func (c *ADCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_DirectoryServices_DirectoryServices
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -117,7 +117,7 @@ type Win32_PerfRawData_Counters_ProcessorInformation struct {
 
 func (c *CPUCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_PerfOS_Processor
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -56,7 +56,7 @@ type Win32_ComputerSystem struct {
 
 func (c *CSCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_ComputerSystem
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -233,7 +233,7 @@ type Win32_PerfRawData_DNS_DNS struct {
 
 func (c *DNSCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_DNS_DNS
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -657,7 +657,7 @@ type Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary
 
 func (c *HyperVCollector) collectVmHealth(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_VmmsVirtualMachineStats_HyperVVirtualMachineHealthSummary
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -689,7 +689,7 @@ type Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition struct {
 
 func (c *HyperVCollector) collectVmVid(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_VidPerfProvider_HyperVVMVidPartition
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -752,7 +752,7 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition struct {
 
 func (c *HyperVCollector) collectVmHv(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorRootPartition
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -889,7 +889,7 @@ type Win32_PerfRawData_HvStats_HyperVHypervisor struct {
 
 func (c *HyperVCollector) collectVmProcessor(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisor
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -923,7 +923,7 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor struct {
 
 func (c *HyperVCollector) collectHostCpuUsage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorRootVirtualProcessor
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -983,7 +983,7 @@ type Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor struct {
 
 func (c *HyperVCollector) collectVmCpuUsage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_HvStats_HyperVHypervisorVirtualProcessor
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -1060,7 +1060,7 @@ type Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch struct {
 
 func (c *HyperVCollector) collectVmSwitch(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NvspSwitchStats_HyperVVirtualSwitch
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -1218,7 +1218,7 @@ type Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter struct {
 
 func (c *HyperVCollector) collectVmEthernet(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_EthernetPerfProvider_HyperVLegacyNetworkAdapter
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -1287,7 +1287,7 @@ type Win32_PerfRawData_Counters_HyperVVirtualStorageDevice struct {
 
 func (c *HyperVCollector) collectVmStorage(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_Counters_HyperVVirtualStorageDevice
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 
@@ -1355,7 +1355,7 @@ type Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter struct {
 
 func (c *HyperVCollector) collectVmNetwork(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NvspNicStats_HyperVVirtualNetworkAdapter
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 

--- a/collector/iis.go
+++ b/collector/iis.go
@@ -995,7 +995,7 @@ var workerProcessNameExtractor = regexp.MustCompile(`^(\d+)_(.+)$`)
 
 func (c *IISCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_W3SVC_WebService
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}
@@ -1248,7 +1248,7 @@ func (c *IISCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 	}
 
 	var dst2 []Win32_PerfRawData_APPPOOLCountersProvider_APPPOOLWAS
-	q2 := wmi.CreateQuery(&dst2, "")
+	q2 := queryAll(&dst2)
 	if err := wmi.Query(q2, &dst2); err != nil {
 		return nil, err
 	}
@@ -1365,7 +1365,7 @@ func (c *IISCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 	}
 
 	var dst_worker []Win32_PerfRawData_W3SVCW3WPCounterProvider_W3SVCW3WP
-	q = wmi.CreateQuery(&dst_worker, "")
+	q = queryAll(&dst_worker)
 	if err := wmi.Query(q, &dst_worker); err != nil {
 		return nil, err
 	}
@@ -1647,7 +1647,7 @@ func (c *IISCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 
 	if iis_version.major >= 8 {
 		var dst_worker_iis8 []Win32_PerfRawData_W3SVCW3WPCounterProvider_W3SVCW3WP_IIS8
-		q = createQuery(&dst_worker_iis8, "Win32_PerfRawData_W3SVCW3WPCounterProvider_W3SVCW3WP", "")
+		q = queryAllForClass(&dst_worker_iis8, "Win32_PerfRawData_W3SVCW3WPCounterProvider_W3SVCW3WP")
 		if err := wmi.Query(q, &dst_worker_iis8); err != nil {
 			return nil, err
 		}
@@ -1730,7 +1730,7 @@ func (c *IISCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 	}
 
 	var dst_cache []Win32_PerfRawData_W3SVC_WebServiceCache
-	q = wmi.CreateQuery(&dst_cache, "")
+	q = queryAll(&dst_cache)
 	if err := wmi.Query(q, &dst_cache); err != nil {
 		return nil, err
 	}

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -161,7 +161,7 @@ type Win32_PerfRawData_PerfDisk_LogicalDisk struct {
 
 func (c *LogicalDiskCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_PerfDisk_LogicalDisk
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -3,7 +3,6 @@
 package collector
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/StackExchange/wmi"
@@ -34,10 +33,7 @@ type Win32_PerfRawData_MSMQ_MSMQQueueCollector struct {
 func NewMSMQCollector() (Collector, error) {
 	const subsystem = "msmq"
 
-	var wc bytes.Buffer
 	if *msmqWhereClause != "" {
-		wc.WriteString("WHERE ")
-		wc.WriteString(*msmqWhereClause)
 		log.Warn("No where-clause specified for msmq collector. This will generate a very large number of metrics!")
 	}
 
@@ -66,7 +62,7 @@ func NewMSMQCollector() (Collector, error) {
 			[]string{"name"},
 			nil,
 		),
-		queryWhereClause: wc.String(),
+		queryWhereClause: *msmqWhereClause,
 	}, nil
 }
 
@@ -91,7 +87,7 @@ type Win32_PerfRawData_MSMQ_MSMQQueue struct {
 
 func (c *Win32_PerfRawData_MSMQ_MSMQQueueCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_MSMQ_MSMQQueue
-	q := wmi.CreateQuery(&dst, c.queryWhereClause)
+	q := queryAllWhere(&dst, c.queryWhereClause)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/net.go
+++ b/collector/net.go
@@ -169,7 +169,7 @@ type Win32_PerfRawData_Tcpip_NetworkInterface struct {
 func (c *NetworkCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_Tcpip_NetworkInterface
 
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -73,7 +73,7 @@ type Win32_PerfRawData_NETFramework_NETCLRExceptions struct {
 
 func (c *NETFramework_NETCLRExceptionsCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRExceptions
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -66,7 +66,7 @@ type Win32_PerfRawData_NETFramework_NETCLRInterop struct {
 
 func (c *NETFramework_NETCLRInteropCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRInterop
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -75,7 +75,7 @@ type Win32_PerfRawData_NETFramework_NETCLRJit struct {
 
 func (c *NETFramework_NETCLRJitCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRJit
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -119,7 +119,7 @@ type Win32_PerfRawData_NETFramework_NETCLRLoading struct {
 
 func (c *NETFramework_NETCLRLoadingCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRLoading
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -99,7 +99,7 @@ type Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads struct {
 
 func (c *NETFramework_NETCLRLocksAndThreadsCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -151,7 +151,7 @@ type Win32_PerfRawData_NETFramework_NETCLRMemory struct {
 
 func (c *NETFramework_NETCLRMemoryCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRMemory
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -89,7 +89,7 @@ type Win32_PerfRawData_NETFramework_NETCLRRemoting struct {
 
 func (c *NETFramework_NETCLRRemotingCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRRemoting
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -74,7 +74,7 @@ type Win32_PerfRawData_NETFramework_NETCLRSecurity struct {
 
 func (c *NETFramework_NETCLRSecurityCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_NETFramework_NETCLRSecurity
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/os.go
+++ b/collector/os.go
@@ -137,7 +137,7 @@ type Win32_OperatingSystem struct {
 
 func (c *OSCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_OperatingSystem
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 

--- a/collector/process.go
+++ b/collector/process.go
@@ -3,7 +3,6 @@
 package collector
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 
@@ -47,11 +46,7 @@ type ProcessCollector struct {
 func NewProcessCollector() (Collector, error) {
 	const subsystem = "process"
 
-	var wc bytes.Buffer
-	if *processWhereClause != "" {
-		wc.WriteString("WHERE ")
-		wc.WriteString(*processWhereClause)
-	} else {
+	if *processWhereClause == "" {
 		log.Warn("No where-clause specified for process collector. This will generate a very large number of metrics!")
 	}
 
@@ -134,7 +129,7 @@ func NewProcessCollector() (Collector, error) {
 			[]string{"process", "process_id", "creating_process_id"},
 			nil,
 		),
-		queryWhereClause: wc.String(),
+		queryWhereClause: *processWhereClause,
 	}, nil
 }
 
@@ -184,7 +179,7 @@ type Win32_PerfRawData_PerfProc_Process struct {
 
 func (c *ProcessCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_PerfProc_Process
-	q := wmi.CreateQuery(&dst, c.queryWhereClause)
+	q := queryAllWhere(&dst, c.queryWhereClause)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/service.go
+++ b/collector/service.go
@@ -3,7 +3,6 @@
 package collector
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/StackExchange/wmi"
@@ -36,11 +35,7 @@ type serviceCollector struct {
 func NewserviceCollector() (Collector, error) {
 	const subsystem = "service"
 
-	var wc bytes.Buffer
-	if *serviceWhereClause != "" {
-		wc.WriteString("WHERE ")
-		wc.WriteString(*serviceWhereClause)
-	} else {
+	if *serviceWhereClause == "" {
 		log.Warn("No where-clause specified for service collector. This will generate a very large number of metrics!")
 	}
 
@@ -63,7 +58,7 @@ func NewserviceCollector() (Collector, error) {
 			[]string{"name", "status"},
 			nil,
 		),
-		queryWhereClause: wc.String(),
+		queryWhereClause: *serviceWhereClause,
 	}, nil
 }
 
@@ -120,7 +115,7 @@ var (
 
 func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_Service
-	q := wmi.CreateQuery(&dst, c.queryWhereClause)
+	q := queryAllWhere(&dst, c.queryWhereClause)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/system.go
+++ b/collector/system.go
@@ -90,7 +90,7 @@ type Win32_PerfRawData_PerfOS_System struct {
 
 func (c *SystemCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_PerfOS_System
-	if err := wmi.Query(wmi.CreateQuery(&dst, ""), &dst); err != nil {
+	if err := wmi.Query(queryAll(&dst), &dst); err != nil {
 		return nil, err
 	}
 

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -114,7 +114,7 @@ type Win32_PerfRawData_Tcpip_TCPv4 struct {
 func (c *TCPCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_Tcpip_TCPv4
 
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -197,7 +197,7 @@ type Win32_PerfRawData_vmGuestLib_VCPU struct {
 
 func (c *VmwareCollector) collectMem(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_vmGuestLib_VMem
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ func mbToBytes(mb uint64) float64 {
 
 func (c *VmwareCollector) collectCpu(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	var dst []Win32_PerfRawData_vmGuestLib_VCPU
-	q := wmi.CreateQuery(&dst, "")
+	q := queryAll(&dst)
 	if err := wmi.Query(q, &dst); err != nil {
 		return nil, err
 	}

--- a/collector/wmi_test.go
+++ b/collector/wmi_test.go
@@ -1,0 +1,115 @@
+package collector
+
+import (
+	"testing"
+)
+
+type fakeWmiClass struct {
+	Name         string
+	SomeProperty int
+}
+
+var (
+	mapQueryAll = func(src interface{}, class string, where string) string {
+		return queryAll(src)
+	}
+	mapQueryAllWhere = func(src interface{}, class string, where string) string {
+		return queryAllWhere(src, where)
+	}
+	mapQueryAllForClass = func(src interface{}, class string, where string) string {
+		return queryAllForClass(src, class)
+	}
+	mapQueryAllForClassWhere = func(src interface{}, class string, where string) string {
+		return queryAllForClassWhere(src, class, where)
+	}
+)
+
+type queryFunc func(src interface{}, class string, where string) string
+
+func TestCreateQuery(t *testing.T) {
+	cases := []struct {
+		desc      string
+		dst       interface{}
+		class     string
+		where     string
+		queryFunc queryFunc
+		expected  string
+	}{
+		{
+			desc:      "queryAll on single instance",
+			dst:       fakeWmiClass{},
+			queryFunc: mapQueryAll,
+			expected:  "SELECT * FROM fakeWmiClass",
+		},
+		{
+			desc:      "queryAll on slice",
+			dst:       []fakeWmiClass{},
+			queryFunc: mapQueryAll,
+			expected:  "SELECT * FROM fakeWmiClass",
+		},
+		{
+			desc:      "queryAllWhere on single instance",
+			dst:       fakeWmiClass{},
+			where:     "foo = bar",
+			queryFunc: mapQueryAllWhere,
+			expected:  "SELECT * FROM fakeWmiClass WHERE foo = bar",
+		},
+		{
+			desc:      "queryAllWhere on slice",
+			dst:       []fakeWmiClass{},
+			where:     "foo = bar",
+			queryFunc: mapQueryAllWhere,
+			expected:  "SELECT * FROM fakeWmiClass WHERE foo = bar",
+		},
+		{
+			desc:      "queryAllWhere on single instance with empty where",
+			dst:       fakeWmiClass{},
+			queryFunc: mapQueryAllWhere,
+			expected:  "SELECT * FROM fakeWmiClass",
+		},
+		{
+			desc:      "queryAllForClass on single instance",
+			dst:       fakeWmiClass{},
+			class:     "someClass",
+			queryFunc: mapQueryAllForClass,
+			expected:  "SELECT * FROM someClass",
+		},
+		{
+			desc:      "queryAllForClass on slice",
+			dst:       []fakeWmiClass{},
+			class:     "someClass",
+			queryFunc: mapQueryAllForClass,
+			expected:  "SELECT * FROM someClass",
+		},
+		{
+			desc:      "queryAllForClassWhere on single instance",
+			dst:       fakeWmiClass{},
+			class:     "someClass",
+			where:     "foo = bar",
+			queryFunc: mapQueryAllForClassWhere,
+			expected:  "SELECT * FROM someClass WHERE foo = bar",
+		},
+		{
+			desc:      "queryAllForClassWhere on slice",
+			dst:       []fakeWmiClass{},
+			class:     "someClass",
+			where:     "foo = bar",
+			queryFunc: mapQueryAllForClassWhere,
+			expected:  "SELECT * FROM someClass WHERE foo = bar",
+		},
+		{
+			desc:      "queryAllForClassWhere on single instance with empty where",
+			dst:       fakeWmiClass{},
+			class:     "someClass",
+			queryFunc: mapQueryAllForClassWhere,
+			expected:  "SELECT * FROM someClass",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			if q := c.queryFunc(c.dst, c.class, c.where); q != c.expected {
+				t.Errorf("Case %q failed: Expected %q, got %q", c.desc, c.expected, q)
+			}
+		})
+	}
+}

--- a/exporter.go
+++ b/exporter.go
@@ -47,7 +47,7 @@ var (
 
 	// This can be removed when client_golang exposes this on Windows
 	// (See https://github.com/prometheus/client_golang/issues/376)
-	startTime = float64(time.Now().Unix())
+	startTime     = float64(time.Now().Unix())
 	startTimeDesc = prometheus.NewDesc(
 		"process_start_time_seconds",
 		"Start time of the process since unix epoch in seconds.",
@@ -169,6 +169,7 @@ func initWbem() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	wmi.DefaultClient.AllowMissingFields = true
 	wmi.DefaultClient.SWbemServicesClient = s
 }
 

--- a/tools/collector-generator/collector.template
+++ b/tools/collector-generator/collector.template
@@ -46,7 +46,7 @@ type {{ .Class }} struct {
 }
 func (c *{{ .CollectorName }}Collector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
     var dst []{{ .Class }}
-    q := wmi.CreateQuery(&dst, "")
+    q := queryAll(&dst)
     if err := wmi.Query(q, &dst); err != nil {
         return nil, err
     }


### PR DESCRIPTION
This PR refactors the query generator to always use a wildcard query (`SELECT * FROM ...`) rather than the explicit listing of all properties (`SELECT Foo, Bar, Baz FROM ...`) that the `wmi` library does.
The advantage in this approach is that any properties that are for some reason missing on a given host will no longer cause the `Invalid query` error we currently get. The corresponding metric will be zero, but the rest will be fine.