### PR TITLE
favicon.ico return 404 not found

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -235,6 +235,7 @@ func main() {
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/health", healthCheck)
+	http.HandleFunc("/favicon.ico", notFound)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, *metricsPath, http.StatusMovedPermanently)
 	})
@@ -258,6 +259,10 @@ func main() {
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	io.WriteString(w, `{"status":"ok"}`)
+}
+
+func notFound(w http.ResponseWriter, r *http.Request) {
+	http.NotFound(w, r)
 }
 
 func keys(m map[string]collector.Collector) []string {


### PR DESCRIPTION
during testing I found that the collectors were getting triggered twice
when hitting the exporter from chome or firefox.

turns out, they were trying to get `/favicon.ico` and the code was
redirecting that request to `/metrics`

added a explicit handler to return 404 NotFound when `/favicon.ico` is
requested.

This issue would not have been triggered with normal requests from prometheus,
only when testing with a browser.