### PR TITLE
fix mssql metric name type

### DIFF
--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -997,7 +997,7 @@ func NewMSSQLCollector() (Collector, error) {
 			nil,
 		),
 		Processesblocked: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "genstatss_blocked_processes"),
+			prometheus.BuildFQName(Namespace, subsystem, "genstats_blocked_processes"),
 			"(GeneralStatistics.Processesblocked)",
 			[]string{"instance"},
 			nil,


### PR DESCRIPTION
found that I had one metric with an extra `s` in `_genstatss_`, making it
inconsistent with it's siblings.