### PR TITLE
Detect duplicates across files in textfile collector

### DIFF
--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -1,14 +1,14 @@
 package collector
 
 import (
-	"testing"
-	"strings"
 	"io/ioutil"
+	"strings"
+	"testing"
 )
 
 func TestCRFilter(t *testing.T) {
 	sr := strings.NewReader("line 1\r\nline 2")
-	cr := carriageReturnFilteringReader{ r: sr }
+	cr := carriageReturnFilteringReader{r: sr}
 	b, err := ioutil.ReadAll(cr)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Fixes #272.
There are still a couple of cases where the textfile collector can cause the entire scrape to fail, but this should solve for a major contributor of the real-world cases, I hope.