### PR TITLE
MSI parameter - EXTRA_FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ Name | Description
 `LISTEN_PORT` | The port to bind to. Defaults to 9182.
 `METRICS_PATH` | The path at which to serve metrics. Defaults to `/metrics`
 `TEXTFILE_DIR` | As the `--collector.textfile.directory` flag, provide a directory to read text files with metrics from
+`EXTRA_FLAGS` | Allows passing full CLI flags. Defaults to an empty string.
 
-Parameters are sent to the installer via `msiexec`. Example invocation:
+Parameters are sent to the installer via `msiexec`. Example invocations:
 
 ```powershell
 msiexec /i <path-to-msi-file> ENABLED_COLLECTORS=os,iis LISTEN_PORT=5000
+```
+
+Example service collector with a custom query.
+```powershell
+msiexec /i <path-to-msi-file> ENABLED_COLLECTORS=os,service --% EXTRA_FLAGS="--collector.service.services-where ""Name LIKE 'sql%'"""
 ```
 
 ## Roadmap

--- a/installer/wmi_exporter.wxs
+++ b/installer/wmi_exporter.wxs
@@ -19,6 +19,9 @@
     <Property Id="ENABLED_COLLECTORS" Secure="yes"/>
     <SetProperty Id="CollectorsFlag" After="InstallFiles" Sequence="execute" Value="--collectors.enabled [ENABLED_COLLECTORS]">ENABLED_COLLECTORS</SetProperty>
 
+    <Property Id="ENABLED_COLLECTOR_SERVICE_FILTERS" Secure="yes"/>
+    <SetProperty Id="CollectorServiceFilterFlag" After="InstallFiles" Sequence="execute" Value="--collector.service.services-where &quot;[ENABLED_COLLECTOR_SERVICE_FILTERS]&quot;">ENABLED_COLLECTOR_SERVICE_FILTERS</SetProperty>
+
     <Property Id="LISTEN_ADDR" Secure="yes" />
     <Property Id="LISTEN_PORT" Secure="yes" Value="9182" />
     <SetProperty Id="ListenFlag" After="InstallFiles" Sequence="execute" Value="--telemetry.addr [LISTEN_ADDR]:[LISTEN_PORT]">LISTEN_ADDR OR LISTEN_PORT</SetProperty>
@@ -42,7 +45,7 @@
         <File Id="wmi_exporter.exe" Name="wmi_exporter.exe" Source="Work\wmi_exporter.exe" KeyPath="yes">
           <fw:FirewallException Id="MetricsEndpoint" Name="WMI Exporter (HTTP [LISTEN_PORT])" Description="WMI Exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" Scope="any" IgnoreFailure="yes" />
         </File>
-        <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" DisplayName="WMI exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirFlag]">
+        <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" DisplayName="WMI exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [CollectorServiceFilterFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirFlag]">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" />
         </ServiceInstall>
         <ServiceControl Id="ServiceStateControl" Name="wmi_exporter" Remove="uninstall" Start="install" Stop="both" />

--- a/installer/wmi_exporter.wxs
+++ b/installer/wmi_exporter.wxs
@@ -19,8 +19,8 @@
     <Property Id="ENABLED_COLLECTORS" Secure="yes"/>
     <SetProperty Id="CollectorsFlag" After="InstallFiles" Sequence="execute" Value="--collectors.enabled [ENABLED_COLLECTORS]">ENABLED_COLLECTORS</SetProperty>
 
-    <Property Id="ENABLED_COLLECTOR_SERVICE_FILTERS" Secure="yes"/>
-    <SetProperty Id="CollectorServiceFilterFlag" After="InstallFiles" Sequence="execute" Value="--collector.service.services-where &quot;[ENABLED_COLLECTOR_SERVICE_FILTERS]&quot;">ENABLED_COLLECTOR_SERVICE_FILTERS</SetProperty>
+    <Property Id="EXTRA_FLAGS" Secure="yes"/>
+    <SetProperty Id="ExtraFlags" After="InstallFiles" Sequence="execute" Value="[EXTRA_FLAGS]">EXTRA_FLAGS</SetProperty>
 
     <Property Id="LISTEN_ADDR" Secure="yes" />
     <Property Id="LISTEN_PORT" Secure="yes" Value="9182" />
@@ -45,7 +45,7 @@
         <File Id="wmi_exporter.exe" Name="wmi_exporter.exe" Source="Work\wmi_exporter.exe" KeyPath="yes">
           <fw:FirewallException Id="MetricsEndpoint" Name="WMI Exporter (HTTP [LISTEN_PORT])" Description="WMI Exporter HTTP endpoint" Port="[LISTEN_PORT]" Protocol="tcp" Scope="any" IgnoreFailure="yes" />
         </File>
-        <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" DisplayName="WMI exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [CollectorServiceFilterFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirFlag]">
+        <ServiceInstall Id="InstallExporterService" Name="wmi_exporter" DisplayName="WMI exporter" Description="Exports Prometheus metrics from WMI queries" ErrorControl="normal" Start="auto" Type="ownProcess" Arguments="--log.format logger:eventlog?name=wmi_exporter [CollectorsFlag] [ListenFlag] [MetricsPathFlag] [TextfileDirFlag] [ExtraFlags]">
           <util:ServiceConfig FirstFailureActionType="restart" SecondFailureActionType="restart" ThirdFailureActionType="restart" RestartServiceDelayInSeconds="5" />
         </ServiceInstall>
         <ServiceControl Id="ServiceStateControl" Name="wmi_exporter" Remove="uninstall" Start="install" Stop="both" />


### PR DESCRIPTION
Added the `ENABLED_COLLECTOR_SERVICE_FILTERS` parameter to the MSI installer in order to allow specifying a custom service query (`collector.service.services-where`).

Example:
```
msiexec /i wmi_exporter-0.5.1-amd64.msi ENABLED_COLLECTORS="service" ENABLED_COLLECTOR_SERVICE_FILTERS="""Name LIKE 'sql%'"""
```

Overall this is a rough attempt (I'm not familiar with MSI/windows packaging) at addressing #170. 