### PR TITLE
textfile collector: Ensure that only UTF8 textfiles are parsed

### DIFF
--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -1,14 +1,15 @@
 package collector
 
 import (
-	"testing"
-	"strings"
+	"github.com/dimchansky/utfbom"
 	"io/ioutil"
+	"strings"
+	"testing"
 )
 
 func TestCRFilter(t *testing.T) {
 	sr := strings.NewReader("line 1\r\nline 2")
-	cr := carriageReturnFilteringReader{ r: sr }
+	cr := carriageReturnFilteringReader{r: sr}
 	b, err := ioutil.ReadAll(cr)
 	if err != nil {
 		t.Error(err)
@@ -16,5 +17,31 @@ func TestCRFilter(t *testing.T) {
 
 	if string(b) != "line 1\nline 2" {
 		t.Errorf("Unexpected output %q", b)
+	}
+}
+
+func TestCheckBOM(t *testing.T) {
+	testdata := []struct {
+		encoding utfbom.Encoding
+		err      string
+	}{
+		{utfbom.Unknown, ""},
+		{utfbom.UTF8, ""},
+		{utfbom.UTF16BigEndian, "UTF16BigEndian"},
+		{utfbom.UTF16LittleEndian, "UTF16LittleEndian"},
+		{utfbom.UTF32BigEndian, "UTF32BigEndian"},
+		{utfbom.UTF32LittleEndian, "UTF32LittleEndian"},
+	}
+	for _, d := range testdata {
+		err := checkBOM(d.encoding)
+		if d.err == "" && err != nil {
+			t.Error(err)
+		}
+		if d.err != "" && err == nil {
+			t.Errorf("Missing expected error %s", d.err)
+		}
+		if err != nil && !strings.Contains(err.Error(), d.err) {
+			t.Error(err)
+		}
 	}
 }


### PR DESCRIPTION
This relates to https://github.com/martinlindhe/wmi_exporter/issues/245#issuecomment-442875445 and expands on #285 

When textfiles in encodings like UTF16LE are encountered, a cryptic error complaining about metric names being in the wrong format will be given. Of course, if a UTF16 file is read as UTF8, they _look_ like they're interspersed with null characters.

This PR causes these inputs to error earlier, with a more useful user-friendly message.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>