### PR TITLE
Adding windows build constraints

### DIFF
--- a/collector/ad.go
+++ b/collector/ad.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_DirectoryServices_DirectoryServices
 // Partial docs: https://msdn.microsoft.com/en-us/library/ms803980.aspx
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_PerfOS_Processor
 // https://msdn.microsoft.com/en-us/library/aa394317(v=vs.90).aspx - Win32_PerfRawData_PerfOS_Processor class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -1,6 +1,8 @@
 // returns data points from Win32_ComputerSystem
 // https://msdn.microsoft.com/en-us/library/aa394102 - Win32_ComputerSystem class
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -1,6 +1,9 @@
 // returns data points from Win32_PerfRawData_DNS_DNS
 // https://msdn.microsoft.com/en-us/library/ms803992.aspx?f=255&MSPPError=-2147217396
 // https://technet.microsoft.com/en-us/library/cc977686.aspx
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package collector
 
 import (

--- a/collector/iis.go
+++ b/collector/iis.go
@@ -4,6 +4,8 @@
 // - Win32_PerfRawData_W3SVCW3WPCounterProvider_W3SVCW3WP
 // - Win32_PerfRawData_W3SVC_WebServiceCache
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -2,6 +2,8 @@
 // https://msdn.microsoft.com/en-us/windows/hardware/aa394307(v=vs.71) - Win32_PerfRawData_PerfDisk_LogicalDisk class
 // https://msdn.microsoft.com/en-us/library/ms803973.aspx - LogicalDisk object reference
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/memory.go
+++ b/collector/memory.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_PerfOS_Memory
 // <add link to documentation here> - Win32_PerfRawData_PerfOS_Memory class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_MSMQ_MSMQQueue
 // <add link to documentation here> - Win32_PerfRawData_MSMQ_MSMQQueue class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -18,6 +18,8 @@
 // - Win32_PerfRawData_MSSQLSERVER_SQLServerSQLStatistics
 //   https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-statistics-object
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/net.go
+++ b/collector/net.go
@@ -4,6 +4,8 @@
 // https://msdn.microsoft.com/en-us/library/aa394216 (Win32_NetworkAdapter class)
 // https://msdn.microsoft.com/en-us/library/aa394353 (Win32_PnPEntity class)
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/net_test.go
+++ b/collector/net_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package collector
 
 import "testing"

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRExceptions
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRExceptions class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRInterop
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRInterop class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRJit
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRJit class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRLoading
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRLoading class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRMemory
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRMemory class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRRemoting
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRRemoting class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_NETFramework_NETCLRSecurity
 // <add link to documentation here> - Win32_PerfRawData_NETFramework_NETCLRSecurity class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/os.go
+++ b/collector/os.go
@@ -1,6 +1,8 @@
 // returns data points from Win32_OperatingSystem
 // https://msdn.microsoft.com/en-us/library/aa394239 - Win32_OperatingSystem class
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/process.go
+++ b/collector/process.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_PerfRawData_PerfProc_Process
 // https://msdn.microsoft.com/en-us/library/aa394323(v=vs.85).aspx - Win32_PerfRawData_PerfProc_Process class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/service.go
+++ b/collector/service.go
@@ -1,5 +1,8 @@
 // returns data points from Win32_Service
 // https://msdn.microsoft.com/en-us/library/aa394418(v=vs.85).aspx - Win32_Service class
+
+// +build windows
+
 package collector
 
 import (

--- a/collector/system.go
+++ b/collector/system.go
@@ -1,6 +1,8 @@
 // returns data points from Win32_PerfRawData_PerfOS_System class
 // https://web.archive.org/web/20050830140516/http://msdn.microsoft.com/library/en-us/wmisdk/wmi/win32_perfrawdata_perfos_system.asp
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -2,6 +2,8 @@
 
 // https://msdn.microsoft.com/en-us/library/aa394341(v=vs.85).aspx (Win32_PerfRawData_Tcpip_TCPv4 class)
 
+// +build windows
+
 package collector
 
 import (

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -1,4 +1,7 @@
 // returns data points from Win32_PerfRawData_vmGuestLib_VMem and Win32_PerfRawData_vmGuestLib_VCPU
+
+// +build windows
+
 package collector
 
 import (

--- a/exporter.go
+++ b/exporter.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package main
 
 import (

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package main
 
 import (


### PR DESCRIPTION
Obviously this isn't totally necessary, as it only makes sense to build this on Windows, but there's at least one collector (`textfille`) that has no Windows-specific dependencies, so can be built (and tested!) on other OSes.

I found this useful while testing #293, so I didn't have to fire up a Windows VM to test changes 😉

Signed-off-by: Dave Henderson <dhenderson@gmail.com>