### PR TITLE
The "collector_duration_seconds_total" metric as histogram to keep duration of full collection.

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -96,7 +96,7 @@ func (coll WmiCollector) Collect(ch chan<- prometheus.Metric) {
 	wg.Wait()
 
 	duration := time.Since(begin)
-	scrapeDurationTotal.Observe(float64(duration))
+	scrapeDurationTotal.Observe(float64(duration) / float64(time.Second))
 	ch <- scrapeDurationTotal
 }
 


### PR DESCRIPTION
The "collector_duration_seconds_total" metric was added to keep duration of full collection. We added it because we noticed some strange dips in graphs(please, see attached screenshot) and the reason is the big time of collecting metrics so that Prometheus cannot collect metrics during scrape timeout. The scrape timeout is 20s in our Prometheus configuration. As a result the existing metric "collector_duration_seconds" does not show us the big time of scraping, because it is gauge.

![image](https://user-images.githubusercontent.com/2204171/52471236-d8e71100-2ba9-11e9-843b-2060a8d461e8.png)

So, the new metric as histogram will measure duration always. Now the metric has the following buckets in seconds:
0.5, 1, 2.5, 5, 10, 15, 20, 25, 30, 45, 60

If you think that it is needed to change this set, please, let me know. Thanks.