### PR TITLE
msmq - incorrect condition to log a warning

### DIFF
--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -33,7 +33,7 @@ type Win32_PerfRawData_MSMQ_MSMQQueueCollector struct {
 func NewMSMQCollector() (Collector, error) {
 	const subsystem = "msmq"
 
-	if *msmqWhereClause != "" {
+	if *msmqWhereClause == "" {
 		log.Warn("No where-clause specified for msmq collector. This will generate a very large number of metrics!")
 	}
 


### PR DESCRIPTION
A warning is logged to event viewer when a where clause is provided - that should, in fact, lower down the results, so the condition had to be inverted.