### PR TITLE
Counter metrics should be exposed as counter rather than gauge

### DIFF
--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -148,50 +148,50 @@ func (c *CPUCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 
 		ch <- prometheus.MustNewConstMetric(
 			c.CStateSecondsTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentC1Time)*ticksToSecondsScaleFactor,
 			core, "c1",
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.CStateSecondsTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentC2Time)*ticksToSecondsScaleFactor,
 			core, "c2",
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.CStateSecondsTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentC3Time)*ticksToSecondsScaleFactor,
 			core, "c3",
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.TimeTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentIdleTime)*ticksToSecondsScaleFactor,
 			core, "idle",
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.TimeTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentInterruptTime)*ticksToSecondsScaleFactor,
 			core, "interrupt",
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.TimeTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentDPCTime)*ticksToSecondsScaleFactor,
 			core, "dpc",
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.TimeTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentPrivilegedTime)*ticksToSecondsScaleFactor,
 			core, "privileged",
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.TimeTotal,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(data.PercentUserTime)*ticksToSecondsScaleFactor,
 			core, "user",
 		)


### PR DESCRIPTION
@martinlindhe Would you mind taking a look at this? My thought was I currently see 

```# HELP wmi_cpu_time_total Time that processor spent in different modes (idle, user, system, ...)
# TYPE wmi_cpu_time_total gauge
wmi_cpu_time_total{core="0",mode="dpc"} 1072.765625
wmi_cpu_time_total{core="0",mode="idle"} 1.6088626299490498e+07
wmi_cpu_time_total{core="0",mode="interrupt"} 1541.28125```
```


When I'd expect
```# HELP wmi_cpu_time_total Time that processor spent in different modes (idle, user, system, ...)
# TYPE wmi_cpu_time_total counter
wmi_cpu_time_total{core="0",mode="dpc"} 1072.765625
wmi_cpu_time_total{core="0",mode="idle"} 1.6088626299490498e+07
wmi_cpu_time_total{core="0",mode="interrupt"} 1541.28125```
