### PR TITLE
Abort scrapes after configurable timeout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,12 +40,13 @@ after_build:
         return
       }
       $ErrorActionPreference = "Stop"
+      $BuildVersion = Get-Content VERSION
       # The MSI version is not semver compliant, so just take the numerical parts
-      $Version = $env:APPVEYOR_REPO_TAG_NAME -replace '^v?([0-9\.]+).*$','$1'
+      $MSIVersion = $env:APPVEYOR_REPO_TAG_NAME -replace '^v?([0-9\.]+).*$','$1'
       foreach($Arch in "amd64","386") {
-        Write-Verbose "Building wmi_exporter $Version msi for $Arch"
-        .\installer\build.ps1 -PathToExecutable .\output\$Arch\wmi_exporter-$Version-$Arch.exe -Version $Version -Arch "$Arch"
-        Move-Item installer\Output\wmi_exporter-$Version-$Arch.msi output\$Arch\
+        Write-Verbose "Building wmi_exporter $MSIVersion msi for $Arch"
+        .\installer\build.ps1 -PathToExecutable .\output\$Arch\wmi_exporter-$BuildVersion-$Arch.exe -Version $MSIVersion -Arch "$Arch"
+        Move-Item installer\Output\wmi_exporter-$MSIVersion-$Arch.msi output\$Arch\
       }
   - promu checksum output\
 

--- a/exporter.go
+++ b/exporter.go
@@ -410,7 +410,7 @@ func (mh *metricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		timeoutSeconds, err = strconv.ParseFloat(v, 64)
 		if err != nil {
-			log.Warnf("Couldn't parse X-Prometheus-Scrape-Timeout-Seconds: %q. Defaulting timeout to %d", v, defaultTimeout)
+			log.Warnf("Couldn't parse X-Prometheus-Scrape-Timeout-Seconds: %q. Defaulting timeout to %f", v, defaultTimeout)
 		}
 	}
 	if timeoutSeconds == 0 {


### PR DESCRIPTION
Depends on #335.
This implements a rough abort after a timeout, so the scrape can return even if WMI has hung for some collectors (eg #89, #270).

I'm not super happy about the implementation, it feels like a mess of interleaved goroutines that are not easy to understand. Tried a few variations of using the normal `context`, but it also had a lot of them. 
Happy for suggestions. Maybe the main `Collect` function should be rewritten.