### PR TITLE
Added metrics to MSSQL collector for base counters

### DIFF
--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -135,49 +135,50 @@ type MSSQLCollector struct {
 	mssqlScrapeSuccessDesc  *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerAccessMethods
-	AccessMethodsAUcleanupbatches             *prometheus.Desc
-	AccessMethodsAUcleanups                   *prometheus.Desc
-	AccessMethodsByreferenceLobCreateCount    *prometheus.Desc
-	AccessMethodsByreferenceLobUseCount       *prometheus.Desc
-	AccessMethodsCountLobReadahead            *prometheus.Desc
-	AccessMethodsCountPullInRow               *prometheus.Desc
-	AccessMethodsCountPushOffRow              *prometheus.Desc
-	AccessMethodsDeferreddroppedAUs           *prometheus.Desc
-	AccessMethodsDeferredDroppedrowsets       *prometheus.Desc
-	AccessMethodsDroppedrowsetcleanups        *prometheus.Desc
-	AccessMethodsDroppedrowsetsskipped        *prometheus.Desc
-	AccessMethodsExtentDeallocations          *prometheus.Desc
-	AccessMethodsExtentsAllocated             *prometheus.Desc
-	AccessMethodsFailedAUcleanupbatches       *prometheus.Desc
-	AccessMethodsFailedleafpagecookie         *prometheus.Desc
-	AccessMethodsFailedtreepagecookie         *prometheus.Desc
-	AccessMethodsForwardedRecords             *prometheus.Desc
-	AccessMethodsFreeSpacePageFetches         *prometheus.Desc
-	AccessMethodsFreeSpaceScans               *prometheus.Desc
-	AccessMethodsFullScans                    *prometheus.Desc
-	AccessMethodsIndexSearches                *prometheus.Desc
-	AccessMethodsInSysXactwaits               *prometheus.Desc
-	AccessMethodsLobHandleCreateCount         *prometheus.Desc
-	AccessMethodsLobHandleDestroyCount        *prometheus.Desc
-	AccessMethodsLobSSProviderCreateCount     *prometheus.Desc
-	AccessMethodsLobSSProviderDestroyCount    *prometheus.Desc
-	AccessMethodsLobSSProviderTruncationCount *prometheus.Desc
-	AccessMethodsMixedpageallocations         *prometheus.Desc
-	AccessMethodsPagecompressionattempts      *prometheus.Desc
-	AccessMethodsPageDeallocations            *prometheus.Desc
-	AccessMethodsPagesAllocated               *prometheus.Desc
-	AccessMethodsPagescompressed              *prometheus.Desc
-	AccessMethodsPageSplits                   *prometheus.Desc
-	AccessMethodsProbeScans                   *prometheus.Desc
-	AccessMethodsRangeScans                   *prometheus.Desc
-	AccessMethodsScanPointRevalidations       *prometheus.Desc
-	AccessMethodsSkippedGhostedRecords        *prometheus.Desc
-	AccessMethodsTableLockEscalations         *prometheus.Desc
-	AccessMethodsUsedleafpagecookie           *prometheus.Desc
-	AccessMethodsUsedtreepagecookie           *prometheus.Desc
-	AccessMethodsWorkfilesCreated             *prometheus.Desc
-	AccessMethodsWorktablesCreated            *prometheus.Desc
-	AccessMethodsWorktablesFromCacheRatio     *prometheus.Desc
+	AccessMethodsAUcleanupbatches              *prometheus.Desc
+	AccessMethodsAUcleanups                    *prometheus.Desc
+	AccessMethodsByreferenceLobCreateCount     *prometheus.Desc
+	AccessMethodsByreferenceLobUseCount        *prometheus.Desc
+	AccessMethodsCountLobReadahead             *prometheus.Desc
+	AccessMethodsCountPullInRow                *prometheus.Desc
+	AccessMethodsCountPushOffRow               *prometheus.Desc
+	AccessMethodsDeferreddroppedAUs            *prometheus.Desc
+	AccessMethodsDeferredDroppedrowsets        *prometheus.Desc
+	AccessMethodsDroppedrowsetcleanups         *prometheus.Desc
+	AccessMethodsDroppedrowsetsskipped         *prometheus.Desc
+	AccessMethodsExtentDeallocations           *prometheus.Desc
+	AccessMethodsExtentsAllocated              *prometheus.Desc
+	AccessMethodsFailedAUcleanupbatches        *prometheus.Desc
+	AccessMethodsFailedleafpagecookie          *prometheus.Desc
+	AccessMethodsFailedtreepagecookie          *prometheus.Desc
+	AccessMethodsForwardedRecords              *prometheus.Desc
+	AccessMethodsFreeSpacePageFetches          *prometheus.Desc
+	AccessMethodsFreeSpaceScans                *prometheus.Desc
+	AccessMethodsFullScans                     *prometheus.Desc
+	AccessMethodsIndexSearches                 *prometheus.Desc
+	AccessMethodsInSysXactwaits                *prometheus.Desc
+	AccessMethodsLobHandleCreateCount          *prometheus.Desc
+	AccessMethodsLobHandleDestroyCount         *prometheus.Desc
+	AccessMethodsLobSSProviderCreateCount      *prometheus.Desc
+	AccessMethodsLobSSProviderDestroyCount     *prometheus.Desc
+	AccessMethodsLobSSProviderTruncationCount  *prometheus.Desc
+	AccessMethodsMixedpageallocations          *prometheus.Desc
+	AccessMethodsPagecompressionattempts       *prometheus.Desc
+	AccessMethodsPageDeallocations             *prometheus.Desc
+	AccessMethodsPagesAllocated                *prometheus.Desc
+	AccessMethodsPagescompressed               *prometheus.Desc
+	AccessMethodsPageSplits                    *prometheus.Desc
+	AccessMethodsProbeScans                    *prometheus.Desc
+	AccessMethodsRangeScans                    *prometheus.Desc
+	AccessMethodsScanPointRevalidations        *prometheus.Desc
+	AccessMethodsSkippedGhostedRecords         *prometheus.Desc
+	AccessMethodsTableLockEscalations          *prometheus.Desc
+	AccessMethodsUsedleafpagecookie            *prometheus.Desc
+	AccessMethodsUsedtreepagecookie            *prometheus.Desc
+	AccessMethodsWorkfilesCreated              *prometheus.Desc
+	AccessMethodsWorktablesCreated             *prometheus.Desc
+	AccessMethodsWorktablesFromCacheRatio      *prometheus.Desc
+	AccessMethodsWorktablesFromCacheRatio_Base *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerAvailabilityReplica
 	AvailReplicaBytesReceivedfromReplica *prometheus.Desc
@@ -193,6 +194,7 @@ type MSSQLCollector struct {
 	// Win32_PerfRawData_{instance}_SQLServerBufferManager
 	BufManBackgroundwriterpages         *prometheus.Desc
 	BufManBuffercachehitratio           *prometheus.Desc
+	BufManBuffercachehitratio_Base       *prometheus.Desc
 	BufManCheckpointpages               *prometheus.Desc
 	BufManDatabasepages                 *prometheus.Desc
 	BufManExtensionallocatedpages       *prometheus.Desc
@@ -251,6 +253,7 @@ type MSSQLCollector struct {
 	DatabasesGroupCommitTime                 *prometheus.Desc
 	DatabasesLogBytesFlushed                 *prometheus.Desc
 	DatabasesLogCacheHitRatio                *prometheus.Desc
+	DatabasesLogCacheHitRatio_Base           *prometheus.Desc
 	DatabasesLogCacheReads                   *prometheus.Desc
 	DatabasesLogFilesSizeKB                  *prometheus.Desc
 	DatabasesLogFilesUsedSizeKB              *prometheus.Desc
@@ -315,13 +318,14 @@ type MSSQLCollector struct {
 	GenStatsUserConnections               *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerLocks
-	LocksAverageWaitTimems    *prometheus.Desc
-	LocksLockRequests         *prometheus.Desc
-	LocksLockTimeouts         *prometheus.Desc
-	LocksLockTimeoutstimeout0 *prometheus.Desc
-	LocksLockWaits            *prometheus.Desc
-	LocksLockWaitTimems       *prometheus.Desc
-	LocksNumberofDeadlocks    *prometheus.Desc
+	LocksAverageWaitTimems      *prometheus.Desc
+	LocksAverageWaitTimems_Base *prometheus.Desc
+	LocksLockRequests           *prometheus.Desc
+	LocksLockTimeouts           *prometheus.Desc
+	LocksLockTimeoutstimeout0   *prometheus.Desc
+	LocksLockWaits              *prometheus.Desc
+	LocksLockWaitTimems         *prometheus.Desc
+	LocksNumberofDeadlocks      *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerMemoryManager
 	MemMgrConnectionMemoryKB       *prometheus.Desc
@@ -642,7 +646,13 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance"},
 			nil,
 		),
-
+		AccessMethodsWorktablesFromCacheRatio_Base: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "accessmethods_worktables_from_cache_ratio"),
+			"(AccessMethods.WorktablesFromCacheRatio_Base)",
+			[]string{"instance"},
+			nil,
+		),
+		
 		// Win32_PerfRawData_{instance}_SQLServerAvailabilityReplica
 		AvailReplicaBytesReceivedfromReplica: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "availreplica_received_from_replica_bytes"),
@@ -709,6 +719,12 @@ func NewMSSQLCollector() (Collector, error) {
 		BufManBuffercachehitratio: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "bufman_buffer_cache_hit_ratio"),
 			"(BufferManager.Buffercachehitratio)",
+			[]string{"instance"},
+			nil,
+		),
+		BufManBuffercachehitratio_Base: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "bufman_buffer_cache_hit_ratio_base"),
+			"(BufferManager.Buffercachehitratio_Base)",
 			[]string{"instance"},
 			nil,
 		),
@@ -1037,6 +1053,12 @@ func NewMSSQLCollector() (Collector, error) {
 		DatabasesLogCacheHitRatio: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "databases_log_cache_hit_ratio"),
 			"(Databases.LogCacheHitRatio)",
+			[]string{"instance", "database"},
+			nil,
+		),
+		DatabasesLogCacheHitRatio_Base: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "databases_log_cache_hit_ratio_base"),
+			"(Databases.LogCacheHitRatio_Base)",
 			[]string{"instance", "database"},
 			nil,
 		),
@@ -1410,6 +1432,12 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance", "resource"},
 			nil,
 		),
+		LocksAverageWaitTimems_Base: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "locks_average_wait_seconds_base"),
+			"(Locks.AverageWaitTimems_Base)",
+			[]string{"instance", "resource"},
+			nil,
+		),
 		LocksLockRequests: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "locks_lock_requests"),
 			"(Locks.LockRequests)",
@@ -1755,6 +1783,7 @@ type win32PerfRawDataSQLServerAccessMethods struct {
 	WorkfilesCreatedPersec        uint64
 	WorktablesCreatedPersec       uint64
 	WorktablesFromCacheRatio      uint64
+	WorktablesFromCacheRatio_Base uint64
 }
 
 func (c *MSSQLCollector) collectAccessMethods(ch chan<- prometheus.Metric, sqlInstance string) (*prometheus.Desc, error) {
@@ -2072,6 +2101,13 @@ func (c *MSSQLCollector) collectAccessMethods(ch chan<- prometheus.Metric, sqlIn
 		float64(v.WorktablesFromCacheRatio),
 		sqlInstance,
 	)
+	
+	ch <- prometheus.MustNewConstMetric(
+		c.AccessMethodsWorktablesFromCacheRatio_Base,
+		prometheus.CounterValue,
+		float64(v.WorktablesFromCacheRatio_Base),
+		sqlInstance,
+	)
 	return nil, nil
 }
 
@@ -2174,6 +2210,7 @@ func (c *MSSQLCollector) collectAvailabilityReplica(ch chan<- prometheus.Metric,
 type win32PerfRawDataSQLServerBufferManager struct {
 	BackgroundwriterpagesPersec   uint64
 	Buffercachehitratio           uint64
+	Buffercachehitratio_Base      uint64
 	CheckpointpagesPersec         uint64
 	Databasepages                 uint64
 	Extensionallocatedpages       uint64
@@ -2222,6 +2259,13 @@ func (c *MSSQLCollector) collectBufferManager(ch chan<- prometheus.Metric, sqlIn
 		c.BufManBuffercachehitratio,
 		prometheus.GaugeValue,
 		float64(v.Buffercachehitratio),
+		sqlInstance,
+	)
+	
+	ch <- prometheus.MustNewConstMetric(
+		c.BufManBuffercachehitratio_Base,
+		prometheus.GaugeValue,
+		float64(v.Buffercachehitratio_Base),
 		sqlInstance,
 	)
 
@@ -2596,6 +2640,7 @@ type win32PerfRawDataSQLServerDatabases struct {
 	GroupCommitTimePersec            uint64
 	LogBytesFlushedPersec            uint64
 	LogCacheHitRatio                 uint64
+	LogCacheHitRatio_Base            uint64
 	LogCacheReadsPersec              uint64
 	LogFilesSizeKB                   uint64
 	LogFilesUsedSizeKB               uint64
@@ -2714,6 +2759,13 @@ func (c *MSSQLCollector) collectDatabases(ch chan<- prometheus.Metric, sqlInstan
 			c.DatabasesLogCacheHitRatio,
 			prometheus.GaugeValue,
 			float64(v.LogCacheHitRatio),
+			sqlInstance, dbName,
+		)
+		
+		ch <- prometheus.MustNewConstMetric(
+			c.DatabasesLogCacheHitRatio_Base,
+			prometheus.GaugeValue,
+			float64(v.LogCacheHitRatio_Base),
 			sqlInstance, dbName,
 		)
 
@@ -3191,6 +3243,7 @@ func (c *MSSQLCollector) collectGeneralStatistics(ch chan<- prometheus.Metric, s
 type win32PerfRawDataSQLServerLocks struct {
 	Name                       string
 	AverageWaitTimems          uint64
+	AverageWaitTimems_Base     uint64
 	LockRequestsPersec         uint64
 	LockTimeoutsPersec         uint64
 	LockTimeoutstimeout0Persec uint64
@@ -3216,6 +3269,13 @@ func (c *MSSQLCollector) collectLocks(ch chan<- prometheus.Metric, sqlInstance s
 			c.LocksAverageWaitTimems,
 			prometheus.GaugeValue,
 			float64(v.AverageWaitTimems)/1000.0,
+			sqlInstance, lockResourceName,
+		)
+		
+		ch <- prometheus.MustNewConstMetric(
+			c.LocksAverageWaitTimems_Base,
+			prometheus.GaugeValue,
+			float64(v.AverageWaitTimems_Base)/1000.0,
 			sqlInstance, lockResourceName,
 		)
 

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -647,7 +647,7 @@ func NewMSSQLCollector() (Collector, error) {
 			nil,
 		),
 		AccessMethodsWorktablesFromCacheRatio_Base: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "accessmethods_worktables_from_cache_ratio"),
+			prometheus.BuildFQName(Namespace, subsystem, "accessmethods_worktables_from_cache_ratio_base"),
 			"(AccessMethods.WorktablesFromCacheRatio_Base)",
 			[]string{"instance"},
 			nil,

--- a/docs/collector.mssql.md
+++ b/docs/collector.mssql.md
@@ -67,6 +67,7 @@ Name | Description | Type | Labels
 `wmi_mssql_accessmethods_workfile_creates` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_accessmethods_worktables_creates` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_accessmethods_worktables_from_cache_ratio` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_accessmethods_worktables_from_cache_ratio_base` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_availreplica_received_from_replica_bytes` | _Not yet documented_ | counter | `instance`, `replica`
 `wmi_mssql_availreplica_sent_to_replica_bytes` | _Not yet documented_ | counter | `instance`, `replica`
 `wmi_mssql_availreplica_sent_to_transport_bytes` | _Not yet documented_ | counter | `instance`, `replica`
@@ -78,6 +79,7 @@ Name | Description | Type | Labels
 `wmi_mssql_availreplica_sends_to_transport` | _Not yet documented_ | counter | `instance`, `replica`
 `wmi_mssql_bufman_background_writer_pages` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_bufman_buffer_cache_hit_ratio` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_bufman_buffer_cache_hit_ratio_base` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_bufman_checkpoint_pages` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_bufman_database_pages` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_bufman_extension_allocated_pages` | _Not yet documented_ | counter | `instance`
@@ -132,6 +134,7 @@ Name | Description | Type | Labels
 `wmi_mssql_databases_group_commit_stall_seconds` | _Not yet documented_ | counter | `instance`, `database`
 `wmi_mssql_databases_log_flushed_bytes` | _Not yet documented_ | counter | `instance`, `database`
 `wmi_mssql_databases_log_cache_hit_ratio` | _Not yet documented_ | counter | `instance`, `database`
+`wmi_mssql_databases_log_cache_hit_ratio_base` | _Not yet documented_ | counter | `instance`, `database`
 `wmi_mssql_databases_log_cache_reads` | _Not yet documented_ | counter | `instance`, `database`
 `wmi_mssql_databases_log_files_size_bytes` | _Not yet documented_ | counter | `instance`, `database`
 `wmi_mssql_databases_log_files_used_size_bytes` | _Not yet documented_ | counter | `instance`, `database`
@@ -193,6 +196,7 @@ Name | Description | Type | Labels
 `wmi_mssql_genstats_transactions` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_genstats_user_connections` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_locks_average_wait_seconds` | _Not yet documented_ | counter | `instance`, `resource`
+`wmi_mssql_locks_average_wait_seconds_base` | _Not yet documented_ | counter | `instance`, `resource`
 `wmi_mssql_locks_lock_requests` | _Not yet documented_ | counter | `instance`, `resource`
 `wmi_mssql_locks_lock_timeouts` | _Not yet documented_ | counter | `instance`, `resource`
 `wmi_mssql_locks_lock_timeouts_excluding_NOWAIT` | _Not yet documented_ | counter | `instance`, `resource`
@@ -235,7 +239,16 @@ Name | Description | Type | Labels
 _This collector does not yet have explained examples, we would appreciate your help adding them!_
 
 ## Useful queries
-_This collector does not yet have any useful queries added, we would appreciate your help adding them!_
+
+### Buffer Cache Hit Ratio
+
+When you read the counter in perfmon you will get the the percentage pages found in the buffer cache. This percentage is calculated internally based on the total number of cache hits divided by the total number of cache lookups over the last few thousand page accesses.
+This collector retrieves the two internal values separately. In order to give any meaning to the value you will have to calculate the Buffer Cache Hit Ratio in PromQL.
+
+```
+wmi_mssql_bufman_buffer_cache_hit_ratio{instance="host:9182", exported_instance="MSSQLSERVER"} / 
+wmi_mssql_bufman_buffer_cache_hit_ratio_base{instance="host:9182", exported_instance="MSSQLSERVER"}
+```
 
 ## Alerting examples
 _This collector does not yet have alerting examples, we would appreciate your help adding them!_


### PR DESCRIPTION
Resolves martinlindhe/wmi_exporter#250

Added metrics for the following base counters:
- wmi_mssql_accessmethods_worktables_from_cache_ratio_base
- wmi_mssql_bufman_buffer_cache_hit_ratio_base
- wmi_mssql_databases_log_cache_hit_ratio_base
- wmi_mssql_locks_average_wait_seconds_base