### PR TITLE
Fix collector creation issue

### DIFF
--- a/tools/collector-generator/New-Collector.ps1
+++ b/tools/collector-generator/New-Collector.ps1
@@ -20,12 +20,12 @@ else {
 $members = @($wmiObject `
     | Get-Member -MemberType Properties `
     | Where-Object { $_.Definition -Match '^u?int' -and $_.Name -NotMatch '_' } `
-    | Select-Object Name, @{Name="Type";Expression={$_.Definition.Split(" ")[0]}}
+    | Select-Object Name, @{Name="Type";Expression={$_.Definition.Split(" ")[0]}})
 $input = @{
     "Class"=$Class;
     "CollectorName"=$CollectorName;
     "Members"=$members
-} | ConvertTo-Json)
+} | ConvertTo-Json
 $outFileName = "..\..\collector\$CollectorName.go".ToLower()
 $input | .\collector-generator.exe | Out-File -NoClobber -Encoding UTF8 $outFileName
 go fmt $outFileName

--- a/tools/collector-generator/New-Collector.ps1
+++ b/tools/collector-generator/New-Collector.ps1
@@ -17,7 +17,7 @@ else {
     $wmiObject = Get-WMIObject -ComputerName $ComputerName -Class $Class
 }
 
-$members = $wmiObject `
+$members = @($wmiObject `
     | Get-Member -MemberType Properties `
     | Where-Object { $_.Definition -Match '^u?int' -and $_.Name -NotMatch '_' } `
     | Select-Object Name, @{Name="Type";Expression={$_.Definition.Split(" ")[0]}}
@@ -25,7 +25,7 @@ $input = @{
     "Class"=$Class;
     "CollectorName"=$CollectorName;
     "Members"=$members
-} | ConvertTo-Json
+} | ConvertTo-Json)
 $outFileName = "..\..\collector\$CollectorName.go".ToLower()
 $input | .\collector-generator.exe | Out-File -NoClobber -Encoding UTF8 $outFileName
 go fmt $outFileName


### PR DESCRIPTION
There is an issue with New-Collector.ps1
When you're trying to create collector from WMI class containing single Perfomance Counter generated JSON output is mailformed in the members definition section. Instead of array it has object definition which breaks template processing with error:

```
panic: json: cannot unmarshal object into Go struct field TemplateData.Members of type []main.Member

goroutine 1 [running]:
main.main()
        C:/Users/ipoly/Desktop/wmi_exporter-master/tools/collector-generator/generate-collector.go:29 +0x4d9
can't load package: package main:
..\..\collector\win32_perfrawdata_mssqlsqlexpress01_mssqlsqlexpress01sqlerrors.go:1:1: expected 'package', found 'EOF'
```

An example of such WMI Class is [Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors ](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-errors-object?view=sql-server-2017) which contains single Errors/sec counter.

JSON output for it:
```
{
    "CollectorName":  "Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors",
    "Members":  {
                    "Name":  "ErrorsPersec",
                    "Type":  "uint64"
                },
    "Class":  "Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors"
}
```
While expected output looks like this (pay attention to array of Members):
```
{
    "CollectorName":  "Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors",
    "Members":  [{
                    "Name":  "ErrorsPersec",
                    "Type":  "uint64"
                }],
    "Class":  "Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors"
}
```
The issue can be bypassed by forcing powershell to cast pipe output to array.