### PR TITLE
Revert "Add container_name label to container collector"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Name     | Description | Enabled by default
 [ad](docs/collector.ad.md) | Active Directory Domain Services |
 [cpu](docs/collector.cpu.md) | CPU usage | &#10003;
 [cs](docs/collector.cs.md) | "Computer System" metrics (system properties, num cpus/total memory) | &#10003;
-[container](docs/collector.container.md) | Container metrics |
 [dns](docs/collector.dns.md) | DNS Server |
 [hyperv](docs/collector.hyperv.md) | Hyper-V hosts |
 [iis](docs/collector.iis.md) | IIS sites and applications |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Name     | Description | Enabled by default
 [ad](docs/collector.ad.md) | Active Directory Domain Services |
 [cpu](docs/collector.cpu.md) | CPU usage | &#10003;
 [cs](docs/collector.cs.md) | "Computer System" metrics (system properties, num cpus/total memory) | &#10003;
+[container](docs/collector.container.md) | Container metrics |
 [dns](docs/collector.dns.md) | DNS Server |
 [hyperv](docs/collector.hyperv.md) | Hyper-V hosts |
 [iis](docs/collector.iis.md) | IIS sites and applications |

--- a/collector/container.go
+++ b/collector/container.go
@@ -45,7 +45,7 @@ func NewContainerMetricsCollector() (Collector, error) {
 		ContainerAvailable: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "available"),
 			"Available",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		ContainersCount: prometheus.NewDesc(
@@ -57,73 +57,73 @@ func NewContainerMetricsCollector() (Collector, error) {
 		UsageCommitBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "memory_usage_commit_bytes"),
 			"Memory Usage Commit Bytes",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		UsageCommitPeakBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "memory_usage_commit_peak_bytes"),
 			"Memory Usage Commit Peak Bytes",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		UsagePrivateWorkingSetBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "memory_usage_private_working_set_bytes"),
 			"Memory Usage Private Working Set Bytes",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		RuntimeTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "cpu_usage_seconds_total"),
 			"Total Run time in Seconds",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		RuntimeUser: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "cpu_usage_seconds_usermode"),
 			"Run Time in User mode in Seconds",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		RuntimeKernel: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "cpu_usage_seconds_kernelmode"),
 			"Run time in Kernel mode in Seconds",
-			[]string{"container_id", "container_name"},
+			[]string{"container_id"},
 			nil,
 		),
 		BytesReceived: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "network_receive_bytes_total"),
 			"Bytes Received on Interface",
-			[]string{"container_id", "container_name", "interface"},
+			[]string{"container_id", "interface"},
 			nil,
 		),
 		BytesSent: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "network_transmit_bytes_total"),
 			"Bytes Sent on Interface",
-			[]string{"container_id", "container_name", "interface"},
+			[]string{"container_id", "interface"},
 			nil,
 		),
 		PacketsReceived: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "network_receive_packets_total"),
 			"Packets Received on Interface",
-			[]string{"container_id", "container_name", "interface"},
+			[]string{"container_id", "interface"},
 			nil,
 		),
 		PacketsSent: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "network_transmit_packets_total"),
 			"Packets Sent on Interface",
-			[]string{"container_id", "container_name", "interface"},
+			[]string{"container_id", "interface"},
 			nil,
 		),
 		DroppedPacketsIncoming: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "network_receive_packets_dropped_total"),
 			"Dropped Incoming Packets on Interface",
-			[]string{"container_id", "container_name", "interface"},
+			[]string{"container_id", "interface"},
 			nil,
 		),
 		DroppedPacketsOutgoing: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "network_transmit_packets_dropped_total"),
 			"Dropped Outgoing Packets on Interface",
-			[]string{"container_id", "container_name", "interface"},
+			[]string{"container_id", "interface"},
 			nil,
 		),
 	}, nil
@@ -169,7 +169,6 @@ func (c *ContainerMetricsCollector) collect(ch chan<- prometheus.Metric) (*prome
 
 	for _, containerDetails := range containers {
 		containerId := containerDetails.ID
-		containerName := containerDetails.Name
 
 		container, err := hcsshim.OpenContainer(containerId)
 		if container != nil {
@@ -192,43 +191,43 @@ func (c *ContainerMetricsCollector) collect(ch chan<- prometheus.Metric) (*prome
 			c.ContainerAvailable,
 			prometheus.CounterValue,
 			1,
-			containerId, containerName,
+			containerId,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.UsageCommitBytes,
 			prometheus.GaugeValue,
 			float64(cstats.Memory.UsageCommitBytes),
-			containerId, containerName,
+			containerId,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.UsageCommitPeakBytes,
 			prometheus.GaugeValue,
 			float64(cstats.Memory.UsageCommitPeakBytes),
-			containerId, containerName,
+			containerId,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.UsagePrivateWorkingSetBytes,
 			prometheus.GaugeValue,
 			float64(cstats.Memory.UsagePrivateWorkingSetBytes),
-			containerId, containerName,
+			containerId,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.RuntimeTotal,
 			prometheus.CounterValue,
 			float64(cstats.Processor.TotalRuntime100ns)*ticksToSecondsScaleFactor,
-			containerId, containerName,
+			containerId,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.RuntimeUser,
 			prometheus.CounterValue,
 			float64(cstats.Processor.RuntimeUser100ns)*ticksToSecondsScaleFactor,
-			containerId, containerName,
+			containerId,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.RuntimeKernel,
 			prometheus.CounterValue,
 			float64(cstats.Processor.RuntimeKernel100ns)*ticksToSecondsScaleFactor,
-			containerId, containerName,
+			containerId,
 		)
 
 		if len(cstats.Network) == 0 {
@@ -243,37 +242,37 @@ func (c *ContainerMetricsCollector) collect(ch chan<- prometheus.Metric) (*prome
 				c.BytesReceived,
 				prometheus.CounterValue,
 				float64(networkInterface.BytesReceived),
-				containerId, containerName, networkInterface.EndpointId,
+				containerId, networkInterface.EndpointId,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.BytesSent,
 				prometheus.CounterValue,
 				float64(networkInterface.BytesSent),
-				containerId, containerName, networkInterface.EndpointId,
+				containerId, networkInterface.EndpointId,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.PacketsReceived,
 				prometheus.CounterValue,
 				float64(networkInterface.PacketsReceived),
-				containerId, containerName, networkInterface.EndpointId,
+				containerId, networkInterface.EndpointId,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.PacketsSent,
 				prometheus.CounterValue,
 				float64(networkInterface.PacketsSent),
-				containerId, containerName, networkInterface.EndpointId,
+				containerId, networkInterface.EndpointId,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.DroppedPacketsIncoming,
 				prometheus.CounterValue,
 				float64(networkInterface.DroppedPacketsIncoming),
-				containerId, containerName, networkInterface.EndpointId,
+				containerId, networkInterface.EndpointId,
 			)
 			ch <- prometheus.MustNewConstMetric(
 				c.DroppedPacketsOutgoing,
 				prometheus.CounterValue,
 				float64(networkInterface.DroppedPacketsOutgoing),
-				containerId, containerName, networkInterface.EndpointId,
+				containerId, networkInterface.EndpointId,
 			)
 			break
 		}


### PR DESCRIPTION
Reverts martinlindhe/wmi_exporter#364. The name property did not actually contain the name, and the property is being deprecated in hcsshim. See discussion in #357.