### PR TITLE
Add support for MSSQL Transactions counters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ VERSION
 *.swp
 *.un~
 output/
+.vscode

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -1672,84 +1672,72 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsLongestTransactionRunningTime: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_longest_transaction_running_seconds"),
 			"(Transactions.LongestTransactionRunningTime)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsNonSnapshotVersionTotalActive: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_nonsnapshot_version_active_total"),
-			"(Transactions.NonSnapshotVersionTotalActive)",
+			"(Transactions.NonSnapshotVersionTransactions)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsSnapshotTotalActive: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_snapshot_active_total"),
-			"(Transactions.SnapshotTotalActive)",
+			"(Transactions.SnapshotTransactions)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsTotalActive: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_active_total"),
-			"(Transactions.TotalActive)",
+			"(Transactions.Transactions)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsUpdateConflictRatio: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_update_conflict_ratio"),
 			"(Transactions.UpdateConflictRatio)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsUpdateSnapshotTotalActive: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_update_snapshot_active_total"),
-			"(Transactions.UpdateSnapshotTotalActive)",
+			"(Transactions.UpdateSnapshotTransactions)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsVersionCleanupRateKBs: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_cleanup_rate_bytes"),
 			"(Transactions.VersionCleanupRateKBs)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsVersionGenerationRateKBs: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_generation_rate_bytes"),
 			"(Transactions.VersionGenerationRateKBs)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsVersionStoreSizeKB: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_size_bytes"),
 			"(Transactions.VersionStoreSizeKB)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsVersionStoreUnitCount: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_units"),
 			"(Transactions.VersionStoreUnitCount)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsVersionStoreUnitCreation: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_creation_units"),
 			"(Transactions.VersionStoreUnitCreation)",
 			[]string{"instance"},
 			nil,
 		),
-
 		TransactionsVersionStoreUnitTruncation: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_truncation_units"),
 			"(Transactions.VersionStoreUnitTruncation)",

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -364,19 +364,19 @@ type MSSQLCollector struct {
 	SQLErrorsTotal *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerTransactions
-	TransactionsFreeSpaceInTempDbKB           *prometheus.Desc
-	TransactionsLongestTransactionRunningTime *prometheus.Desc
-	TransactionsNonSnapshotVersionTotalActive *prometheus.Desc
-	TransactionsSnapshotTotalActive           *prometheus.Desc
-	TransactionsTotalActive                   *prometheus.Desc
-	TransactionsUpdateConflictRatio           *prometheus.Desc
-	TransactionsUpdateSnapshotTotalActive     *prometheus.Desc
-	TransactionsVersionCleanupRateKBs         *prometheus.Desc
-	TransactionsVersionGenerationRateKBs      *prometheus.Desc
-	TransactionsVersionStoreSizeKB            *prometheus.Desc
-	TransactionsVersionStoreUnitCount         *prometheus.Desc
-	TransactionsVersionStoreUnitCreation      *prometheus.Desc
-	TransactionsVersionStoreUnitTruncation    *prometheus.Desc
+	TransactionsTempDbFreeSpaceBytes             *prometheus.Desc
+	TransactionsLongestTransactionRunningSeconds *prometheus.Desc
+	TransactionsNonSnapshotVersionActiveTotal    *prometheus.Desc
+	TransactionsSnapshotActiveTotal              *prometheus.Desc
+	TransactionsActiveTotal                      *prometheus.Desc
+	TransactionsUpdateConflictRatio              *prometheus.Desc
+	TransactionsUpdateSnapshotActiveTotal        *prometheus.Desc
+	TransactionsVersionCleanupRateBytes          *prometheus.Desc
+	TransactionsVersionGenerationRateBytes       *prometheus.Desc
+	TransactionsVersionStoreSizeBytes            *prometheus.Desc
+	TransactionsVersionStoreUnits                *prometheus.Desc
+	TransactionsVersionStoreCreationUnits        *prometheus.Desc
+	TransactionsVersionStoreTruncationUnits      *prometheus.Desc
 
 	mssqlInstances             mssqlInstancesType
 	mssqlCollectors            mssqlCollectorsMap
@@ -1666,31 +1666,31 @@ func NewMSSQLCollector() (Collector, error) {
 		),
 
 		// Win32_PerfRawData_{instance}_SQLServerTransactions
-		TransactionsFreeSpaceInTempDbKB: prometheus.NewDesc(
+		TransactionsTempDbFreeSpaceBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_tempdb_free_space_bytes"),
 			"(Transactions.FreeSpaceInTempDbKB)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsLongestTransactionRunningTime: prometheus.NewDesc(
+		TransactionsLongestTransactionRunningSeconds: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_longest_transaction_running_seconds"),
 			"(Transactions.LongestTransactionRunningTime)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsNonSnapshotVersionTotalActive: prometheus.NewDesc(
+		TransactionsNonSnapshotVersionActiveTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_nonsnapshot_version_active_total"),
 			"(Transactions.NonSnapshotVersionTransactions)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsSnapshotTotalActive: prometheus.NewDesc(
+		TransactionsSnapshotActiveTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_snapshot_active_total"),
 			"(Transactions.SnapshotTransactions)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsTotalActive: prometheus.NewDesc(
+		TransactionsActiveTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_active_total"),
 			"(Transactions.Transactions)",
 			[]string{"instance"},
@@ -1702,43 +1702,43 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsUpdateSnapshotTotalActive: prometheus.NewDesc(
+		TransactionsUpdateSnapshotActiveTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_update_snapshot_active_total"),
 			"(Transactions.UpdateSnapshotTransactions)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsVersionCleanupRateKBs: prometheus.NewDesc(
+		TransactionsVersionCleanupRateBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_cleanup_rate_bytes"),
 			"(Transactions.VersionCleanupRateKBs)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsVersionGenerationRateKBs: prometheus.NewDesc(
+		TransactionsVersionGenerationRateBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_generation_rate_bytes"),
 			"(Transactions.VersionGenerationRateKBs)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsVersionStoreSizeKB: prometheus.NewDesc(
+		TransactionsVersionStoreSizeBytes: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_size_bytes"),
 			"(Transactions.VersionStoreSizeKB)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsVersionStoreUnitCount: prometheus.NewDesc(
+		TransactionsVersionStoreUnits: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_units"),
 			"(Transactions.VersionStoreUnitCount)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsVersionStoreUnitCreation: prometheus.NewDesc(
+		TransactionsVersionStoreCreationUnits: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_creation_units"),
 			"(Transactions.VersionStoreUnitCreation)",
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsVersionStoreUnitTruncation: prometheus.NewDesc(
+		TransactionsVersionStoreTruncationUnits: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_version_store_truncation_units"),
 			"(Transactions.VersionStoreUnitTruncation)",
 			[]string{"instance"},
@@ -3733,35 +3733,35 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	v := dst[0]
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsFreeSpaceInTempDbKB,
+		c.TransactionsTempDbFreeSpaceBytes,
 		prometheus.GaugeValue,
-		float64(v.FreeSpaceintempdbKB),
+		float64(v.FreeSpaceintempdbKB*1024),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsLongestTransactionRunningTime,
+		c.TransactionsLongestTransactionRunningSeconds,
 		prometheus.GaugeValue,
 		float64(v.LongestTransactionRunningTime),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsNonSnapshotVersionTotalActive,
+		c.TransactionsNonSnapshotVersionActiveTotal,
 		prometheus.CounterValue,
 		float64(v.NonSnapshotVersionTransactions),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsSnapshotTotalActive,
+		c.TransactionsSnapshotActiveTotal,
 		prometheus.CounterValue,
 		float64(v.SnapshotTransactions),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsTotalActive,
+		c.TransactionsActiveTotal,
 		prometheus.CounterValue,
 		float64(v.Transactions),
 		sqlInstance,
@@ -3775,49 +3775,49 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsUpdateSnapshotTotalActive,
+		c.TransactionsUpdateSnapshotActiveTotal,
 		prometheus.CounterValue,
 		float64(v.UpdateSnapshotTransactions),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsVersionCleanupRateKBs,
+		c.TransactionsVersionCleanupRateBytes,
 		prometheus.GaugeValue,
-		float64(v.VersionCleanuprateKBPers),
+		float64(v.VersionCleanuprateKBPers*1024),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsVersionGenerationRateKBs,
+		c.TransactionsVersionGenerationRateBytes,
 		prometheus.GaugeValue,
-		float64(v.VersionGenerationrateKBPers),
+		float64(v.VersionGenerationrateKBPers*1024),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsVersionStoreSizeKB,
+		c.TransactionsVersionStoreSizeBytes,
 		prometheus.GaugeValue,
-		float64(v.VersionStoreSizeKB),
+		float64(v.VersionStoreSizeKB*1024),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsVersionStoreUnitCount,
+		c.TransactionsVersionStoreUnits,
 		prometheus.CounterValue,
 		float64(v.VersionStoreunitcount),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsVersionStoreUnitCreation,
+		c.TransactionsVersionStoreCreationUnits,
 		prometheus.CounterValue,
 		float64(v.VersionStoreunitcreation),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsVersionStoreUnitTruncation,
+		c.TransactionsVersionStoreTruncationUnits,
 		prometheus.CounterValue,
 		float64(v.VersionStoreunittruncation),
 		sqlInstance,

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -361,22 +361,22 @@ type MSSQLCollector struct {
 	SQLStatsUnsafeAutoParams        *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerSQLErrors
-	SQLErrorsTotal                  *prometheus.Desc
+	SQLErrorsTotal *prometheus.Desc
 
 	// Win32_PerfRawData_{instance}_SQLServerTransactions
-	TransactionsFreeSpaceInTempDbKB            *prometheus.Desc
-	TransactionsLongestTransactionRunningTime  *prometheus.Desc
-	TransactionsNonSnapshotVersionTotalActive  *prometheus.Desc
-	TransactionsSnapshotTotalActive            *prometheus.Desc
-	TransactionsTotalActive                    *prometheus.Desc
-	TransactionsUpdateConflictRatio            *prometheus.Desc
-	TransactionsUpdateSnapshotTotalActive      *prometheus.Desc
-	TransactionsVersionCleanupRateKBs          *prometheus.Desc
-	TransactionsVersionGenerationRateKBs       *prometheus.Desc
-	TransactionsVersionStoreSizeKB             *prometheus.Desc
-	TransactionsVersionStoreUnitCount          *prometheus.Desc
-	TransactionsVersionStoreUnitCreation       *prometheus.Desc
-	TransactionsVersionStoreUnitTruncation     *prometheus.Desc
+	TransactionsFreeSpaceInTempDbKB           *prometheus.Desc
+	TransactionsLongestTransactionRunningTime *prometheus.Desc
+	TransactionsNonSnapshotVersionTotalActive *prometheus.Desc
+	TransactionsSnapshotTotalActive           *prometheus.Desc
+	TransactionsTotalActive                   *prometheus.Desc
+	TransactionsUpdateConflictRatio           *prometheus.Desc
+	TransactionsUpdateSnapshotTotalActive     *prometheus.Desc
+	TransactionsVersionCleanupRateKBs         *prometheus.Desc
+	TransactionsVersionGenerationRateKBs      *prometheus.Desc
+	TransactionsVersionStoreSizeKB            *prometheus.Desc
+	TransactionsVersionStoreUnitCount         *prometheus.Desc
+	TransactionsVersionStoreUnitCreation      *prometheus.Desc
+	TransactionsVersionStoreUnitTruncation    *prometheus.Desc
 
 	mssqlInstances             mssqlInstancesType
 	mssqlCollectors            mssqlCollectorsMap
@@ -1666,7 +1666,7 @@ func NewMSSQLCollector() (Collector, error) {
 		),
 
 		// Win32_PerfRawData_{instance}_SQLServerTransactions
-	    TransactionsFreeSpaceInTempDbKB: prometheus.NewDesc(
+		TransactionsFreeSpaceInTempDbKB: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "transactions_tempdb_free_space_bytes"),
 			"(Transactions.FreeSpaceInTempDbKB)",
 			[]string{"instance"},
@@ -1756,7 +1756,7 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance"},
 			nil,
 		),
-		
+
 		mssqlInstances: getMSSQLInstances(),
 	}
 
@@ -3680,8 +3680,8 @@ func (c *MSSQLCollector) collectSQLStats(ch chan<- prometheus.Metric, sqlInstanc
 }
 
 type win32PerfRawDataSQLServerSQLErrors struct {
-	Name      string
-	Errorssec uint64
+	Name         string
+	ErrorsPersec uint64
 }
 
 // Win32_PerfRawData_MSSQLSERVER_SQLServerErrors docs:
@@ -3702,7 +3702,7 @@ func (c *MSSQLCollector) collectSQLErrors(ch chan<- prometheus.Metric, sqlInstan
 		ch <- prometheus.MustNewConstMetric(
 			c.SQLErrorsTotal,
 			prometheus.CounterValue,
-			float64(v.Errorssec),
+			float64(v.ErrorsPersec),
 			sqlInstance, resource,
 		)
 	}
@@ -3711,19 +3711,19 @@ func (c *MSSQLCollector) collectSQLErrors(ch chan<- prometheus.Metric, sqlInstan
 }
 
 type win32PerfRawDataSqlServerTransactions struct {
-	FreeSpaceInTempDbKB            uint64
+	FreeSpaceintempdbKB            uint64
 	LongestTransactionRunningTime  uint64
 	NonSnapshotVersionTransactions uint64
 	SnapshotTransactions           uint64
 	Transactions                   uint64
-	UpdateConflictRatio            uint64
+	Updateconflictratio            uint64
 	UpdateSnapshotTransactions     uint64
-	VersionCleanupRateKBs          uint64
-	VersionGenerationRateKBs       uint64
+	VersionCleanuprateKBPers       uint64
+	VersionGenerationrateKBPers    uint64
 	VersionStoreSizeKB             uint64
-	VersionStoreUnitCount          uint64
-	VersionStoreUnitCreation       uint64
-	VersionStoreUnitTruncation     uint64
+	VersionStoreunitcount          uint64
+	VersionStoreunitcreation       uint64
+	VersionStoreunittruncation     uint64
 }
 
 // Win32_PerfRawData_MSSQLSERVER_Transactions docs:
@@ -3747,7 +3747,7 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsFreeSpaceInTempDbKB,
 		prometheus.GaugeValue,
-		float64(v.FreeSpaceInTempDbKB),
+		float64(v.FreeSpaceintempdbKB),
 		sqlInstance,
 	)
 
@@ -3782,7 +3782,7 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsUpdateConflictRatio,
 		prometheus.GaugeValue,
-		float64(v.UpdateConflictRatio),
+		float64(v.Updateconflictratio),
 		sqlInstance,
 	)
 
@@ -3796,14 +3796,14 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsVersionCleanupRateKBs,
 		prometheus.GaugeValue,
-		float64(v.VersionCleanupRateKBs),
+		float64(v.VersionCleanuprateKBPers),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsVersionGenerationRateKBs,
 		prometheus.GaugeValue,
-		float64(v.VersionGenerationRateKBs),
+		float64(v.VersionGenerationrateKBPers),
 		sqlInstance,
 	)
 
@@ -3817,21 +3817,21 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsVersionStoreUnitCount,
 		prometheus.CounterValue,
-		float64(v.VersionStoreUnitCount),
+		float64(v.VersionStoreunitcount),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsVersionStoreUnitCreation,
 		prometheus.CounterValue,
-		float64(v.VersionStoreUnitCreation),
+		float64(v.VersionStoreunitcreation),
 		sqlInstance,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
 		c.TransactionsVersionStoreUnitTruncation,
 		prometheus.CounterValue,
-		float64(v.VersionStoreUnitTruncation),
+		float64(v.VersionStoreunittruncation),
 		sqlInstance,
 	)
 

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -369,7 +369,7 @@ type MSSQLCollector struct {
 	TransactionsNonSnapshotVersionActiveTotal    *prometheus.Desc
 	TransactionsSnapshotActiveTotal              *prometheus.Desc
 	TransactionsActiveTotal                      *prometheus.Desc
-	TransactionsUpdateConflictRatio              *prometheus.Desc
+	TransactionsUpdateConflictsTotal             *prometheus.Desc
 	TransactionsUpdateSnapshotActiveTotal        *prometheus.Desc
 	TransactionsVersionCleanupRateBytes          *prometheus.Desc
 	TransactionsVersionGenerationRateBytes       *prometheus.Desc
@@ -1696,8 +1696,8 @@ func NewMSSQLCollector() (Collector, error) {
 			[]string{"instance"},
 			nil,
 		),
-		TransactionsUpdateConflictRatio: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, subsystem, "transactions_update_conflict_ratio"),
+		TransactionsUpdateConflictsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "transactions_update_conflicts_total"),
 			"(Transactions.UpdateConflictRatio)",
 			[]string{"instance"},
 			nil,
@@ -3768,8 +3768,8 @@ func (c *MSSQLCollector) collectTransactions(ch chan<- prometheus.Metric, sqlIns
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		c.TransactionsUpdateConflictRatio,
-		prometheus.GaugeValue,
+		c.TransactionsUpdateConflictsTotal,
+		prometheus.CounterValue,
 		float64(v.Updateconflictratio),
 		sqlInstance,
 	)

--- a/docs/collector.mssql.md
+++ b/docs/collector.mssql.md
@@ -236,7 +236,7 @@ Name | Description | Type | Labels
 `wmi_mssql_transactions_nonsnapshot_version_active_total` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_transactions_snapshot_active_total` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_transactions_active_total` | _Not yet documented_ | counter | `instance`
-`wmi_mssql_transactions_update_conflict_ratio` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_update_conflicts_total` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_transactions_update_snapshot_active_total` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_transactions_version_cleanup_rate_bytes` | _Not yet documented_ | gauge | `instance`
 `wmi_mssql_transactions_version_generation_rate_bytes` | _Not yet documented_ | gauge | `instance`

--- a/docs/collector.mssql.md
+++ b/docs/collector.mssql.md
@@ -5,14 +5,14 @@ The mssql collector exposes metrics about the MSSQL server
 |||
 -|-
 Metric name prefix  | `mssql`
-Classes             | [`Win32_PerfRawData_MSSQLSERVER_SQLServerAccessMethods`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-access-methods-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerAvailabilityReplica`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-availability-replica)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerBufferManager`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-buffer-manager-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerDatabaseReplica`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-database-replica)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerDatabases`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-databases-object?view=sql-server-2017)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerGeneralStatistics`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-general-statistics-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerLocks`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-locks-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerMemoryManager`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-memory-manager-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerSQLStatistics`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-statistics-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-errors-object)
+Classes             | [`Win32_PerfRawData_MSSQLSERVER_SQLServerAccessMethods`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-access-methods-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerAvailabilityReplica`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-availability-replica)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerBufferManager`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-buffer-manager-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerDatabaseReplica`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-database-replica)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerDatabases`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-databases-object?view=sql-server-2017)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerGeneralStatistics`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-general-statistics-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerLocks`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-locks-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerMemoryManager`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-memory-manager-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerSQLStatistics`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-statistics-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerSQLErrors`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-sql-errors-object)<br/>[`Win32_PerfRawData_MSSQLSERVER_SQLServerTransactions`](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-transactions-object)
 Enabled by default? | No
 
 ## Flags
 
 ### `--collectors.mssql.classes-enabled`
 
-Comma-separated list of MSSQL WMI classes to use. Supported values are `accessmethods`, `availreplica`, `bufman`, `databases`, `dbreplica`, `genstats`, `locks`, `memmgr`, `sqlstats` and `sqlerrors`.
+Comma-separated list of MSSQL WMI classes to use. Supported values are `accessmethods`, `availreplica`, `bufman`, `databases`, `dbreplica`, `genstats`, `locks`, `memmgr`, `sqlstats`, `sqlerrors` and `transactions`.
 
 ### `--collectors.mssql.class-print`
 
@@ -231,6 +231,19 @@ Name | Description | Type | Labels
 `wmi_mssql_sqlstats_sql_recompilations` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_sqlstats_unsafe_auto_parameterization_attempts` | _Not yet documented_ | counter | `instance`
 `wmi_mssql_sql_errors_total` | _Not yet documented_ | counter | `instance`, `resource`
+`wmi_mssql_transactions_tempdb_free_space_bytes` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_longest_transaction_running_seconds` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_nonsnapshot_version_active_total` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_transactions_snapshot_active_total` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_transactions_active_total` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_transactions_update_conflict_ratio` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_update_snapshot_active_total` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_transactions_version_cleanup_rate_bytes` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_version_generation_rate_bytes` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_version_store_size_bytes` | _Not yet documented_ | gauge | `instance`
+`wmi_mssql_transactions_version_store_units` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_transactions_version_store_creation_units` | _Not yet documented_ | counter | `instance`
+`wmi_mssql_transactions_version_store_truncation_units` | _Not yet documented_ | counter | `instance`
 
 ### Example metric
 _This collector does not yet have explained examples, we would appreciate your help adding them!_


### PR DESCRIPTION
Pull request changes:
+ Add support for [Transactions counters](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-transactions-object)
+ Fix wrong counter name for errors count (#370). I forgot to push changes, sorry :(

Also I'm not pretty happy with some counter names:
```
transactions_nonsnapshot_version_active_total
transactions_snapshot_active_total
transactions_active_total
transactions_update_snapshot_active_total
```
If follow the original microsoft naming pattern, they should be called
```
transactions_nonsnapshot_version_transactions
transactions_snapshot_transactions
transactions_transactions
transactions_update_snapshot_transactions
```
It's again a bit redundant, so I replaced the `transactions` suffix with `active_total` which is more appropriate in terms of Prometheus naming convention. I decided to add `active` because microsoft docs says about only active transactions but not transactions at all. This detail may not be obvious if we use just `total` prefix. But as I mentioned I'm not really sure if this decision is trully correct. Therefore if there are any suggestions on how names can be enchanced, feel free to share them :) 