### PR TITLE
Remove cgo build tag from container collector

### DIFF
--- a/collector/container.go
+++ b/collector/container.go
@@ -1,4 +1,4 @@
-// +build windows,cgo
+// +build windows
 
 package collector
 


### PR DESCRIPTION
Fixes #391 
The build tag was added to make building without access to a gcc toolchain easier, but for some reason it seems to not be enabled during CI either. It should be put back, but to fix the immediate problem (the `container` collector hasn't been built into 0.8.x) let's just remove it.