### PR TITLE
Added a required detail for the .prom file to work properly

### DIFF
--- a/docs/collector.textfile.md
+++ b/docs/collector.textfile.md
@@ -12,7 +12,7 @@ Enabled by default? | Yes
 
 ### `--collector.textfile.directory`
 
-The directory containing the files to be ingested. Only files with the extension `.prom` are read.
+The directory containing the files to be ingested. Only files with the extension `.prom` are read. The `.prom` file must end with an empty line feed to work properly.
 
 Default value: `C:\Program Files\wmi_exporter\textfile_inputs`
 


### PR DESCRIPTION
After adding the `role.prom` file on Windows on around 15 virtual machines, we discovered that if we omit to insert an empty line feed at the end of the file, Prometheus won't get metrics from the virtual machine. Adding a new line fixes the issue and immediately start gathering metrics for the virtual machine.