### PR TITLE
Set tcp_connections_established to gauge type

### DIFF
--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -136,7 +136,7 @@ func (c *TCPCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, e
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.ConnectionsEstablished,
-		prometheus.CounterValue,
+		prometheus.GaugeValue,
 		float64(dst[0].ConnectionsEstablished),
 	)
 	ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Resolves #407

While the ConnectionsEstablished property in the
Win32_PerfRawData_Tcpip_TCP class is listed as a counter, real-world
metric values have been shown to increase *and* decrease.

Documentation for the property states "Number of TCP connections for
which the **current** state is either ESTABLISHED or CLOSE-WAIT" which
would imply the metric is a gauge.

No other class properties have shown this behaviour.