### PR TITLE
Add product name & version to os collector

### DIFF
--- a/docs/collector.os.md
+++ b/docs/collector.os.md
@@ -16,6 +16,7 @@ None
 
 Name | Description | Type | Labels
 -----|-------------|------|-------
+`wmi_os_info` | Contains full product name & version in labels | gauge | `product`, `version`
 `wmi_os_paging_limit_bytes` | Total number of bytes that can be sotred in the operating system paging files. 0 (zero) indicates that there are no paging files | gauge | None
 `wmi_os_paging_free_bytes` | Number of bytes that can be mapped into the operating system paging files without causing any other pages to be swapped out | gauge | None
 `wmi_os_physical_memory_free_bytes` | Bytes of physical memory currently unused and available | gauge | None


### PR DESCRIPTION
I'm pretty sure I've seen an issue or PR with that before, but it would be really cool to have this info as a metric, similar to `wmi_exporter_build_info` since I really don't want another PowerShell script running, just this shiny exporter.
I could also split these in two metrics, but in my opinion they belong together and would just waste space.