### PR TITLE
Build badge should only reflect master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WMI exporter
 
-[![Build status](https://ci.appveyor.com/api/projects/status/ljwan71as6pf2joe?svg=true)](https://ci.appveyor.com/project/martinlindhe/wmi-exporter)
+[![Build status](https://ci.appveyor.com/api/projects/status/ljwan71as6pf2joe/branch/master?svg=true)](https://ci.appveyor.com/project/martinlindhe/wmi-exporter)
 
 Prometheus exporter for Windows machines, using the WMI (Windows Management Instrumentation).
 


### PR DESCRIPTION
Currently the last build sets that build status badge in the README. It should just show the state of master, not some random PR.