### PR TITLE
Add collector for hostname information

### DIFF
--- a/collector/cs.go
+++ b/collector/cs.go
@@ -18,6 +18,7 @@ func init() {
 type CSCollector struct {
 	PhysicalMemoryBytes *prometheus.Desc
 	LogicalProcessors   *prometheus.Desc
+	Hostname            *prometheus.Desc
 }
 
 // NewCSCollector ...
@@ -35,6 +36,15 @@ func NewCSCollector() (Collector, error) {
 			prometheus.BuildFQName(Namespace, subsystem, "physical_memory_bytes"),
 			"ComputerSystem.TotalPhysicalMemory",
 			nil,
+			nil,
+		),
+		Hostname: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, subsystem, "hostname"),
+			"Labeled system hostname information as provided by ComputerSystem.DNSHostName and ComputerSystem.Domain",
+			[]string{
+				"hostname",
+				"domain",
+				"fqdn"},
 			nil,
 		),
 	}, nil
@@ -55,6 +65,9 @@ func (c *CSCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metric) e
 type Win32_ComputerSystem struct {
 	NumberOfLogicalProcessors uint32
 	TotalPhysicalMemory       uint64
+	DNSHostname               string
+	Domain                    string
+	Workgroup                 string
 }
 
 func (c *CSCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
@@ -77,6 +90,22 @@ func (c *CSCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, er
 		c.PhysicalMemoryBytes,
 		prometheus.GaugeValue,
 		float64(dst[0].TotalPhysicalMemory),
+	)
+
+	var fqdn string
+	if dst[0].Domain != dst[0].Workgroup {
+		fqdn = dst[0].DNSHostname + "." + dst[0].Domain
+	} else {
+		fqdn = dst[0].DNSHostname
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.Hostname,
+		prometheus.GaugeValue,
+		1.0,
+		dst[0].DNSHostname,
+		dst[0].Domain,
+		fqdn,
 	)
 
 	return nil, nil

--- a/docs/collector.cs.md
+++ b/docs/collector.cs.md
@@ -18,6 +18,7 @@ Name | Description | Type | Labels
 -----|-------------|------|-------
 `wmi_cs_logical_processors` | Number of installed logical processors | gauge | None
 `wmi_cs_physical_memory_bytes` | Total installed physical memory | gauge | None
+`wmi_cs_hostname` | Labeled system hostname information | gauge | `hostname`, `domain`, `fqdn`
 
 ### Example metric
 _This collector does not yet have explained examples, we would appreciate your help adding them!_


### PR DESCRIPTION
This can be useful for building grafana dashboards with dropdowns for multiple hosts.
Or for managed instances of Prometheus where the user is not able to add labels via config.

It is built in a similar way as node_exporter already does it with its uname metric.

Fixes #409 #160 #454