### PR TITLE
BREAKING: Remove redirect from unknown paths to /metrics

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -335,7 +335,13 @@ func main() {
 	http.Handle(*metricsPath, h)
 	http.HandleFunc("/health", healthCheck)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, *metricsPath, http.StatusMovedPermanently)
+		_, _ = w.Write([]byte(`<html>
+<head><title>WMI Exporter</title></head>
+<body>
+<h1>WMI Exporter</h1>
+<p><a href="` + *metricsPath + `">Metrics</a></p>
+</body>
+</html>`))
 	})
 
 	log.Infoln("Starting WMI exporter", version.Info())


### PR DESCRIPTION
This PR removes the redirect from any unhandled path to /metrics. This behaviour has been with us since the beginning, but I'd like to finally remove it. 
This will break any existing installs that has assumptions about this, but do not set the `--telemetry.path` flag to whatever path they use. 