### PR TITLE
Fix README for process whitelist and expand docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,9 @@ The prometheus metrics will be exposed on [localhost:9182](http://localhost:9182
 
 ### Enable only process collector and specify a custom query
 
-    .\wmi_exporter.exe --collectors.enabled "process" --collector.process.processes-where "Name LIKE 'firefox%'"
+    .\wmi_exporter.exe --collectors.enabled "process" --collector.process.whitelist="firefox.+"
 
-When there are multiple processes with the same name, WMI represents those after the first instance as `process-name#index`. So to get them all, rather than just the first one, the query needs to be a wildcard search using a `%` character.
-
-Please note that in Windows batch scripts (and when using the `cmd` command prompt), the `%` character is reserved, so it has to be escaped with another `%`. For example, the wildcard syntax for searching for all firefox processes is `firefox%%`.
+When there are multiple processes with the same name, WMI represents those after the first instance as `process-name#index`. So to get them all, rather than just the first one, the [regular expression](https://en.wikipedia.org/wiki/Regular_expression) must use `.+`. See [process](docs/collector.process.md) for more information.
 
 
 ## License

--- a/docs/collector.process.md
+++ b/docs/collector.process.md
@@ -26,8 +26,16 @@ metrics.
 ### Example
 To match all firefox processes: `--collector.process.whitelist="firefox.+"`.
 Note that multiple processes with the same name will be disambiguated by
-Windows by adding a number suffix, such as `firefox#2`. Your regexp must take
+Windows by adding a number suffix, such as `firefox#2`. Your [regexp](https://en.wikipedia.org/wiki/Regular_expression) must take
 these suffixes into consideration.
+
+:warning: The regexp is case-sensitive, so `--collector.process.whitelist="FIREFOX.+"` will **NOT** match a process named `firefox` . 
+
+To specify multiple names, use the pipe `|` character:
+```
+--collector.process.whitelist="firefox.+|FIREFOX.+|chrome.+"
+```
+This will match all processes named `firefox`, `FIREFOX` or `chrome` .
 
 ## Metrics
 


### PR DESCRIPTION
Since PR #489 `--collector.process.processes-where` no longer works, changing example in `README` to use `--collector.process.whitelist` with regexp.

Also expand docs for process filter regexp a little bit.