### PR TITLE
adfs collector missing dependency

### DIFF
--- a/collector/adfs.go
+++ b/collector/adfs.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registerCollector("adfs", newADFSCollector)
+	registerCollector("adfs", newADFSCollector, "AD FS")
 }
 
 type adfsCollector struct {


### PR DESCRIPTION
The adfs collector doesn't register the perflib dependency after the `registerCollector` refactoring in #461.
Fixes #503