### PR TITLE
add wmi_service_info metric with display_name and pid labels

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/StackExchange/wmi"
@@ -43,19 +44,19 @@ func NewserviceCollector() (Collector, error) {
 		State: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "state"),
 			"The state of the service (State)",
-			[]string{"name", "state"},
+			[]string{"name", "display_name", "process_id", "state"},
 			nil,
 		),
 		StartMode: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "start_mode"),
 			"The start mode of the service (StartMode)",
-			[]string{"name", "start_mode"},
+			[]string{"name", "display_name", "process_id", "start_mode"},
 			nil,
 		),
 		Status: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, subsystem, "status"),
 			"The status of the service (Status)",
-			[]string{"name", "status"},
+			[]string{"name", "display_name", "process_id", "status"},
 			nil,
 		),
 		queryWhereClause: *serviceWhereClause,
@@ -75,10 +76,12 @@ func (c *serviceCollector) Collect(ctx *ScrapeContext, ch chan<- prometheus.Metr
 // Win32_Service docs:
 // - https://msdn.microsoft.com/en-us/library/aa394418(v=vs.85).aspx
 type Win32_Service struct {
-	Name      string
-	State     string
-	Status    string
-	StartMode string
+	DisplayName string
+	Name        string
+	ProcessId   uint32
+	State       string
+	Status      string
+	StartMode   string
 }
 
 var (
@@ -123,6 +126,8 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 	}
 
 	for _, service := range dst {
+		pid := strconv.FormatUint(uint64(service.ProcessId), 10)
+
 		for _, state := range allStates {
 			isCurrentState := 0.0
 			if state == strings.ToLower(service.State) {
@@ -133,6 +138,8 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 				prometheus.GaugeValue,
 				isCurrentState,
 				strings.ToLower(service.Name),
+				service.DisplayName,
+				pid,
 				state,
 			)
 		}
@@ -147,6 +154,8 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 				prometheus.GaugeValue,
 				isCurrentStartMode,
 				strings.ToLower(service.Name),
+				service.DisplayName,
+				pid,
 				startMode,
 			)
 		}
@@ -161,6 +170,8 @@ func (c *serviceCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 				prometheus.GaugeValue,
 				isCurrentStatus,
 				strings.ToLower(service.Name),
+				service.DisplayName,
+				pid,
 				status,
 			)
 		}

--- a/docs/collector.service.md
+++ b/docs/collector.service.md
@@ -20,6 +20,7 @@ Example: `--collector.service.services-where="Name='wmi_exporter'"`
 
 Name | Description | Type | Labels
 -----|-------------|------|-------
+`wmi_service_info` | Contains service information in labels, constant 1 | gauge | name, display_name, process_id
 `wmi_service_state` | The state of the service, 1 if the current state, 0 otherwise | gauge | name, state
 `wmi_service_start_mode` | The start mode of the service, 1 if the current start mode, 0 otherwise | gauge | name, start_mode
 `wmi_service_status` | The status of the service, 1 if the current status, 0 otherwise | gauge | name, status


### PR DESCRIPTION
I have added the `wmi_service_info` metric to the service collector including `display_name` and `process_id` of the service.

This labels would make service troubleshooting easier since service explorer shows DisplayName in the columns and the pid help to identify the running process  
I tested this in Windows server 16
#514 