### PR TITLE
Replace Get-WMIObject with Get-CimInstance for PS7 support

### DIFF
--- a/tools/collector-generator/New-Collector.ps1
+++ b/tools/collector-generator/New-Collector.ps1
@@ -11,10 +11,10 @@ Param(
 $ErrorActionPreference = "Stop"
 
 if($Credential -ne $null) {
-    $wmiObject = Get-WMIObject -ComputerName $ComputerName -Credential $Credential -Class $Class
+    $wmiObject = Get-CimInstance -ComputerName $ComputerName -Credential $Credential -Class $Class
 }
 else {
-    $wmiObject = Get-WMIObject -ComputerName $ComputerName -Class $Class
+    $wmiObject = Get-CimInstance -ComputerName $ComputerName -Class $Class
 }
 
 $members = $wmiObject `


### PR DESCRIPTION
This is somewhat related to https://github.com/martinlindhe/wmi_exporter/issues/522

Where I ran into issues with the generator. I tried to run it in Powershell 7.0.1 but found out that Get-WMIObject is no longer supported as Powershell 7 is based on .Net Core and .Net Core does not support WMI. We will have to use Get-CimInstance instead.
